### PR TITLE
Fix shebang to work on generic linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The cookiecutter template in this repository will create a new Generative AI Too
 #### Prereqs
 
 - Install [cookiecutter](https://www.cookiecutter.io/), e.g. with: `pipx install cookiecutter`
+- Install [uv](https://github.com/astral-sh/uv) (the cookiecutter template uses `uv` to install Python dependencies; basically as a faster `pip`)
+- Install [Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (for installing and using AWS CDK)
+- You need to have Python 3.12 or higher (can easily be installed with `uv`, e.g.: `uv python install 3.12`)
 
 #### Usage
 

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -euo pipefail
+#!/bin/bash
+set -euo pipefail
 
 # Copyright 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #

--- a/hooks/pre_prompt.sh
+++ b/hooks/pre_prompt.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -euo pipefail
+#!/bin/bash
+set -euo pipefail
 
 # Copyright 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fix shebang in cookiecutter scripts to work on generic linux (e.g. SageMaker notebooks)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
