### PR TITLE
fix: use term user in LLM prompt for ConversationExpectationMetric

### DIFF
--- a/src/generative_ai_toolkit/metrics/modules/conversation.py
+++ b/src/generative_ai_toolkit/metrics/modules/conversation.py
@@ -69,7 +69,7 @@ class ConversationExpectationMetric(BaseMetric):
                             "text": textwrap.dedent(
                                 """
                                 You will be given two inputs:
-                                1. Conversation between a car driver and an LLM agent.
+                                1. Conversation between a user and an LLM agent.
                                 2. Developer provided expectations for the LLM agent's responses.
 
                                 You will compare the actual conversation against the provided expectations.


### PR DESCRIPTION
*Issue #, if available:* #13 

*Description of changes:* Use "user" instead of "car driver"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
