### PR TITLE
feat: support optional tool parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,13 @@ If you don't want to register a Python function as tool, but have a tool with to
 
 ```python
 from typing import Any
-from generative_ai_toolkit.agent.tool import ToolSpec
+from mypy_boto3_bedrock_runtime.type_defs import ToolSpecificationTypeDef
 
 class MyTool:
-    name = "my-tool"
 
     @property
-    def tool_spec(self) -> ToolSpec:
-        return {"toolSpec":{"name":"my-tool","description":"This tool helps with ...", "inputSchema": {...}}}
+    def tool_spec(self) -> ToolSpecificationTypeDef:
+        return {"name":"my-tool","description":"This tool helps with ...", "inputSchema": {...}}
 
     def invoke(self, *args, **kwargs) -> Any:
         return "Tool response"

--- a/src/generative_ai_toolkit/agent/agent.py
+++ b/src/generative_ai_toolkit/agent/agent.py
@@ -493,7 +493,7 @@ class BedrockConverseAgent(Agent):
         """
         if callable(tool):
             tool = BedrockConverseTool(tool)
-        self._tools[tool.name] = tool
+        self._tools[tool.tool_spec["name"]] = tool
         return tool
 
     @staticmethod
@@ -639,11 +639,15 @@ class BedrockConverseAgent(Agent):
                 BedrockConverseTool(tool) if callable(tool) else tool for tool in tools
             ]
             tools_available = (
-                {tool.name: tool for tool in tools} if tools is not None else {}
+                {tool.tool_spec["name"]: tool for tool in tools}
+                if tools is not None
+                else {}
             )
         if tools_available:
             request["toolConfig"] = {
-                "tools": [tool.tool_spec for tool in tools_available.values()],
+                "tools": [
+                    {"toolSpec": tool.tool_spec} for tool in tools_available.values()
+                ],
             }
 
         texts: list[str] = []
@@ -799,11 +803,15 @@ class BedrockConverseAgent(Agent):
                 BedrockConverseTool(tool) if callable(tool) else tool for tool in tools
             ]
             tools_available = (
-                {tool.name: tool for tool in tools} if tools is not None else {}
+                {tool.tool_spec["name"]: tool for tool in tools}
+                if tools is not None
+                else {}
             )
         if tools_available:
             request["toolConfig"] = {
-                "tools": [tool.tool_spec for tool in tools_available.values()],
+                "tools": [
+                    {"toolSpec": tool.tool_spec} for tool in tools_available.values()
+                ],
             }
 
         def update_content_blocks(

--- a/src/generative_ai_toolkit/test/__init__.py
+++ b/src/generative_ai_toolkit/test/__init__.py
@@ -289,7 +289,7 @@ class Case:
             ],
         )
         return Case(
-            name=case_name or f"Tool use: {tool.name}",
+            name=case_name or f"Tool use: {tool.tool_spec["name"]}",
             user_inputs=[get_text(response)],
         )
 

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from generative_ai_toolkit.agent import BedrockConverseTool
+from generative_ai_toolkit.agent import BedrockConverseTool, Tool
 
 
 def test_tool():
@@ -23,14 +23,30 @@ def test_tool():
         """This is a sample function"""
         return "Hello World"
 
-    tool = BedrockConverseTool(sample_function)
-    assert tool.name == "sample_function"
+    tool: Tool = BedrockConverseTool(sample_function)
     assert tool.tool_spec == {
-        "toolSpec": {
-            "name": "sample_function",
-            "description": "This is a sample function",
-            "inputSchema": {"json": {"type": "object", "properties": {}}},
-        }
+        "name": "sample_function",
+        "description": "This is a sample function",
+        "inputSchema": {"json": {"type": "object", "properties": {}}},
+    }
+    assert tool.invoke() == "Hello World"
+
+
+def test_tool_with_multiline_description():
+
+    def sample_function():
+        """
+        This is a sample function.
+
+        And it's great!
+        """
+        return "Hello World"
+
+    tool: Tool = BedrockConverseTool(sample_function)
+    assert tool.tool_spec == {
+        "name": "sample_function",
+        "description": "This is a sample function.\n\nAnd it's great!",
+        "inputSchema": {"json": {"type": "object", "properties": {}}},
     }
     assert tool.invoke() == "Hello World"
 
@@ -39,7 +55,9 @@ def test_tool_with_parameters():
 
     def sample_function_with_parameters(parameter1: str, parameter2: int):
         """
-        This is a sample function with parameters
+        This is a sample function with parameters.
+
+        And it's great!
 
         Parameters
         ---
@@ -50,28 +68,26 @@ def test_tool_with_parameters():
         """
         return f"Hello World {parameter1} {parameter2}"
 
-    tool = BedrockConverseTool(sample_function_with_parameters)
-    assert tool.name == "sample_function_with_parameters"
+    tool: Tool = BedrockConverseTool(sample_function_with_parameters)
     assert tool.tool_spec == {
-        "toolSpec": {
-            "name": "sample_function_with_parameters",
-            "description": "This is a sample function with parameters",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "parameter1": {
-                            "type": "string",
-                            "description": "The first parameter",
-                        },
-                        "parameter2": {
-                            "type": "integer",
-                            "description": "The second parameter",
-                        },
+        "name": "sample_function_with_parameters",
+        "description": "This is a sample function with parameters.\n\nAnd it's great!",
+        "inputSchema": {
+            "json": {
+                "type": "object",
+                "properties": {
+                    "parameter1": {
+                        "type": "string",
+                        "description": "The first parameter",
                     },
-                }
-            },
-        }
+                    "parameter2": {
+                        "type": "integer",
+                        "description": "The second parameter",
+                    },
+                },
+                "required": ["parameter1", "parameter2"],
+            }
+        },
     }
     assert tool.invoke(parameter1="foo", parameter2=1) == "Hello World foo 1"
 
@@ -93,7 +109,7 @@ def test_tool_with_optional_parameters():
         """
         return f"Hello World {parameter1} {parameter2}"
 
-    tool1 = BedrockConverseTool(sample_function_with_optional_parameters_1)
+    tool1: Tool = BedrockConverseTool(sample_function_with_optional_parameters_1)
 
     def sample_function_with_optional_parameters_2(
         parameter1: str, parameter2: int | None = None
@@ -112,30 +128,30 @@ def test_tool_with_optional_parameters():
             parameter2 = 1
         return f"Hello World {parameter1} {parameter2}"
 
-    tool2 = BedrockConverseTool(sample_function_with_optional_parameters_2)
+    tool2: Tool = BedrockConverseTool(sample_function_with_optional_parameters_2)
 
     for index, tool in enumerate([tool1, tool2]):
-        assert tool.name == f"sample_function_with_optional_parameters_{index + 1}"
         assert tool.tool_spec == {
-            "toolSpec": {
-                "name": f"sample_function_with_optional_parameters_{index + 1}",
-                "description": "This is a sample function with optional parameters",
-                "inputSchema": {
-                    "json": {
-                        "type": "object",
-                        "properties": {
-                            "parameter1": {
-                                "type": "string",
-                                "description": "The first parameter",
-                            },
-                            "parameter2": {
-                                "type": "integer",
-                                "description": "The second parameter",
-                            },
+            "name": f"sample_function_with_optional_parameters_{index + 1}",
+            "description": "This is a sample function with optional parameters",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "parameter1": {
+                            "type": "string",
+                            "description": "The first parameter",
                         },
-                    }
-                },
-            }
+                        "parameter2": {
+                            "type": "integer",
+                            "description": "The second parameter",
+                        },
+                    },
+                    "required": [
+                        "parameter1",
+                    ],
+                }
+            },
         }
         assert tool.invoke(parameter1="foo") == "Hello World foo 1"
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Follow up on #24 to add `required` property to the JSON Schema for tool parameters. Also reworked the datamodel slightly, so tools expose the toolspec object unwrapped (before, it was wrapped inside: `{"toolSpec": ... }`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
