### PR TITLE
feat: add more pragmatic JSON encoder for Tool results

### DIFF
--- a/src/generative_ai_toolkit/agent/tool.py
+++ b/src/generative_ai_toolkit/agent/tool.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import inspect
+import json
 import re
 import textwrap
 from collections.abc import Callable
+from datetime import date, datetime, time
 from types import UnionType
 from typing import TYPE_CHECKING, Any, Protocol, Union, get_args, get_origin
 
@@ -37,6 +39,15 @@ class Tool(Protocol):
         Invoke the tool
         """
         ...
+
+
+class ToolResultJsonEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, date | datetime | time):
+            return o.isoformat()
+        elif hasattr(o, "__json__") and callable(o.__json__):
+            return o.__json__()
+        return super().default(o)
 
 
 class BedrockConverseTool(Tool):

--- a/src/generative_ai_toolkit/test/mock.py
+++ b/src/generative_ai_toolkit/test/mock.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Unpack
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, Unpack
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 class ToolUseOutput(TypedDict):
     name: str
     input: dict[str, Any]
+    toolUseId: NotRequired[str]
 
 
 RealResponse = Literal["RealResponse"]
@@ -114,7 +115,7 @@ class MockBedrockConverse:
         text_output: Sequence[str] = (),
     ):
         tool_uses: list[ContentBlockOutputTypeDef] = [
-            {"toolUse": {**t, "toolUseId": uuid4().hex}} for t in tool_use_output
+            {"toolUse": {"toolUseId": uuid4().hex, **t}} for t in tool_use_output
         ]
         texts: list[ContentBlockOutputTypeDef] = [{"text": t} for t in text_output]
         self.mock_responses.append(self._get_raw_response([*tool_uses, *texts]))

--- a/src/generative_ai_toolkit/ui/__init__.py
+++ b/src/generative_ai_toolkit/ui/__init__.py
@@ -99,14 +99,14 @@ def get_markdown_for_tool_invocation(tool_trace: Trace):
     res = textwrap.dedent(
         f"""
         **Input**
-        {json.dumps(tool_input)}
+        {tool_input}
         """
     )
     if tool_output:
         res += textwrap.dedent(
             f"""
             **Output**
-            {json.dumps(tool_output)}
+            {tool_output}
             """
         )
     if tool_error:

--- a/tests/unit/test_tool_response.py
+++ b/tests/unit/test_tool_response.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from datetime import UTC, date, datetime, time
+
+from generative_ai_toolkit.agent import BedrockConverseAgent
+from generative_ai_toolkit.agent.tool import (
+    ToolResultJsonEncoder,
+)
+
+
+class Foo:
+    def __json__(self):
+        return {
+            "foo": "bar",
+            "bar": datetime(2021, 1, 1, 1, 1, 1, tzinfo=UTC),
+            "baz": date(2022, 2, 2),
+            "qux": time(1, 2, 3, 4),
+        }
+
+
+def test_tool_result_json_encoder():
+    foo = Foo()
+
+    assert (
+        json.dumps(foo, cls=ToolResultJsonEncoder)
+        == '{"foo": "bar", "bar": "2021-01-01T01:01:01+00:00", "baz": "2022-02-02", "qux": "01:02:03.000004"}'
+    )
+
+
+def test_agent_tool_json_response(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        session=mock_bedrock_converse.session(),
+    )
+
+    def foo():
+        """
+        Return a Foo
+        """
+        return Foo()
+
+    agent.register_tool(foo)
+    mock_bedrock_converse.add_output(
+        tool_use_output=[{"name": "foo", "input": {}, "toolUseId": "abc123"}]
+    )
+    mock_bedrock_converse.add_output(text_output=["done"])
+    agent.converse("test")
+    tool_result_msg = agent.messages[-2]
+    assert tool_result_msg["content"][0] == {
+        "toolResult": {
+            "content": [
+                {
+                    "json": {
+                        "toolResponse": {
+                            "bar": "2021-01-01T01:01:01+00:00",
+                            "baz": "2022-02-02",
+                            "foo": "bar",
+                            "qux": "01:02:03.000004",
+                        },
+                    },
+                },
+            ],
+            "status": "success",
+            "toolUseId": "abc123",
+        },
+    }
+
+
+def test_agent_tool_json_response_custom_encoder(mock_bedrock_converse):
+    class MyJsonEncoder(json.JSONEncoder):
+        def default(self, o):
+            if isinstance(o, Foo):
+                return "That's a foo!"
+            return super().default(o)
+
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        session=mock_bedrock_converse.session(),
+        tool_result_json_encoder=MyJsonEncoder,
+    )
+
+    def foo():
+        """
+        Return a Foo
+        """
+        return Foo()
+
+    agent.register_tool(foo)
+    mock_bedrock_converse.add_output(
+        tool_use_output=[{"name": "foo", "input": {}, "toolUseId": "abc123"}]
+    )
+    mock_bedrock_converse.add_output(text_output=["done"])
+    agent.converse("test")
+    tool_result_msg = agent.messages[-2]
+    assert tool_result_msg["content"][0] == {
+        "toolResult": {
+            "content": [
+                {
+                    "json": {
+                        "toolResponse": "That's a foo!",
+                    },
+                },
+            ],
+            "status": "success",
+            "toolUseId": "abc123",
+        },
+    }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added a more pragmatic JSON encoder for Tool results. Before, e.g. datetimes in tool responses would raise a JSON Encoder error, now these get JSON encoded as ISO string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
