### PR TITLE
fix: reorganize imports to avoid circular dependency

### DIFF
--- a/src/generative_ai_toolkit/metrics/measurement.py
+++ b/src/generative_ai_toolkit/metrics/measurement.py
@@ -14,43 +14,13 @@
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
-
-# These units are supported by Amazon CloudWatch metrics:
-class Unit(Enum):
-    Seconds = "Seconds"
-    Microseconds = "Microseconds"
-    Milliseconds = "Milliseconds"
-    Bytes = "Bytes"
-    Kilobytes = "Kilobytes"
-    Megabytes = "Megabytes"
-    Gigabytes = "Gigabytes"
-    Terabytes = "Terabytes"
-    Bits = "Bits"
-    Kilobits = "Kilobits"
-    Megabits = "Megabits"
-    Gigabits = "Gigabits"
-    Terabits = "Terabits"
-    Percent = "Percent"
-    Count = "Count"
-    BytesPerSecond = "Bytes/Second"
-    KilobytesPerSecond = "Kilobytes/Second"
-    MegabytesPerSecond = "Megabytes/Second"
-    GigabytesPerSecond = "Gigabytes/Second"
-    TerabytesPerSecond = "Terabytes/Second"
-    BitsPerSecond = "Bits/Second"
-    KilobitsPerSecond = "Kilobits/Second"
-    MegabitsPerSecond = "Megabits/Second"
-    GigabitsPerSecond = "Gigabits/Second"
-    TerabitsPerSecond = "Terabits/Second"
-    CountPerSecond = "Count/Second"
-    None_ = "None"
+from generative_ai_toolkit.utils.cloudwatch import MetricData, Unit
 
 
 @dataclass
-class Measurement:
+class Measurement(MetricData):
     name: str
     value: int | float | Sequence[int | float]
     unit: Unit = Unit.None_

--- a/src/generative_ai_toolkit/utils/cloudwatch.py
+++ b/src/generative_ai_toolkit/utils/cloudwatch.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from typing import Protocol
+
+
+class Unit(Enum):
+    """
+    Amazon CloudWatch Metrics compatible unit
+    """
+
+    Seconds = "Seconds"
+    Microseconds = "Microseconds"
+    Milliseconds = "Milliseconds"
+    Bytes = "Bytes"
+    Kilobytes = "Kilobytes"
+    Megabytes = "Megabytes"
+    Gigabytes = "Gigabytes"
+    Terabytes = "Terabytes"
+    Bits = "Bits"
+    Kilobits = "Kilobits"
+    Megabits = "Megabits"
+    Gigabits = "Gigabits"
+    Terabits = "Terabits"
+    Percent = "Percent"
+    Count = "Count"
+    BytesPerSecond = "Bytes/Second"
+    KilobytesPerSecond = "Kilobytes/Second"
+    MegabytesPerSecond = "Megabytes/Second"
+    GigabytesPerSecond = "Gigabytes/Second"
+    TerabytesPerSecond = "Terabytes/Second"
+    BitsPerSecond = "Bits/Second"
+    KilobitsPerSecond = "Kilobits/Second"
+    MegabitsPerSecond = "Megabits/Second"
+    GigabitsPerSecond = "Gigabits/Second"
+    TerabitsPerSecond = "Terabits/Second"
+    CountPerSecond = "Count/Second"
+    None_ = "None"
+
+
+class MetricData(Protocol):
+    name: str
+    value: int | float | Sequence[int | float]
+    unit: Unit
+    dimensions: Sequence[Mapping[str, str]]

--- a/src/generative_ai_toolkit/utils/logging.py
+++ b/src/generative_ai_toolkit/utils/logging.py
@@ -30,7 +30,7 @@ import traceback
 from collections.abc import Mapping
 from typing import Any, TextIO
 
-from generative_ai_toolkit.metrics.measurement import Measurement
+from generative_ai_toolkit.utils.cloudwatch import MetricData
 
 in_aws_lambda = os.environ.get("AWS_EXECUTION_ENV", "").startswith("AWS_Lambda_")
 
@@ -100,7 +100,7 @@ class SimpleLogger:
 
     def metric(
         self,
-        measurement: Measurement,
+        metric_data: MetricData,
         namespace: str,
         message="CloudWatch Embedded Metric",
         common_dimensions: Mapping[str, str] | None = None,
@@ -109,8 +109,8 @@ class SimpleLogger:
     ):
         common_dimensions = {**common_dimensions} if common_dimensions else {}
         dimension_sets = (
-            [{**dim_set, **common_dimensions} for dim_set in measurement.dimensions]
-            if measurement.dimensions
+            [{**dim_set, **common_dimensions} for dim_set in metric_data.dimensions]
+            if metric_data.dimensions
             else [common_dimensions]
         )
         accumulated_dimensions: Mapping[str, str] = {}
@@ -120,7 +120,7 @@ class SimpleLogger:
         if len(accumulated_dimensions) > 9:
             raise ValueError("More than 9 dimensions provided")
         log_data: Mapping[str, Any] = {
-            measurement.name: measurement.value,
+            metric_data.name: metric_data.value,
         }
         for k, v in kwargs.items():
             if v is not None:
@@ -134,8 +134,8 @@ class SimpleLogger:
                         {
                             "Metrics": [
                                 {
-                                    "Name": measurement.name,
-                                    "Unit": measurement.unit.value,
+                                    "Name": metric_data.name,
+                                    "Unit": metric_data.unit.value,
                                 }
                             ],
                             "Dimensions": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Reorganized imports to avoid circular dependency. Before, just importing the logger, but not the entire toolkit failed. Now, this no longer fails:

```python
from generative_ai_toolkit.utils.logging import logger
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
