### PR TITLE
feat: support reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,58 @@ agent = BedrockConverseAgent(
 )
 ```
 
+##### Reasoning
+
+If you want to use reasoning with a model that supports it (e.g. `anthropic.claude-3-7-sonnet-20250219-v1:0`), specify `additional_model_request_fields`:
+
+```python
+from generative_ai_toolkit.agent import BedrockConverseAgent
+
+agent = BedrockConverseAgent(
+    model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+    additional_model_request_fields={
+        "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+    },
+)
+```
+
+Then, when calling `converse` or `converse_stream`, reasoning texts will be included within `<thinking>` tags in the output:
+
+```python
+response = agent.converse("How should I make Spaghetti Carbonara?")
+print(response)
+```
+
+Would print e.g.:
+
+```
+<thinking>
+The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.
+
+The required parameter for this function is:
+- dish: The name of the dish to get a recipe for
+
+In this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user's request, so I can call the function with this parameter.
+</thinking>
+
+I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
+Here is the recipe ...
+```
+
+If you do not want to include the reasoning texts in the output, you can turn that off like so:
+
+```python
+from generative_ai_toolkit.agent import BedrockConverseAgent
+
+agent = BedrockConverseAgent(
+    model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+    additional_model_request_fields={
+        "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+    },
+    include_reasoning_text_within_thinking_tags=False, # set this to False
+)
+```
+
 #### Tools
 
 If you want to give the agent access to tools, you can define them as Python functions, and register them with the agent. Your Python function must have type annotations for input and output, and a docstring like so:
@@ -373,6 +425,8 @@ In the OpenTelemetry Span model, information such as "the model ID used for the 
 | `ai.llm.response.usage`                  | Usage metrics from the LLM response                                                                                                                                                               |
 | `ai.llm.response.metrics`                | Additional metrics from the LLM response                                                                                                                                                          |
 | `ai.llm.response.error`                  | Error information if the LLM request fails                                                                                                                                                        |
+| `ai.llm.response.trace`                  | Trace information                                                                                                                                                                                 |
+| `ai.llm.response.performance.config`     | The performance config                                                                                                                                                                            |
 | `ai.agent.response`                      | The final concatenated response from the agent                                                                                                                                                    |
 | `service.name`                           | Name of the service, set to the class name of the agent                                                                                                                                           |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,23 @@ build-backend = "setuptools.build_meta"
 name = "generative-ai-toolkit"
 version = "0.7.1"
 description = "Toolkit to support developers in building and operating high quality LLM-based applications"
-keywords = ["generative-ai-toolkit", "generative-ai", "gen-ai", "agent", "llm", "testing"]
+keywords = [
+    "generative-ai-toolkit",
+    "generative-ai",
+    "gen-ai",
+    "agent",
+    "llm",
+    "testing",
+]
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "Apache-2.0"}
-dependencies = [
-    "boto3~=1.37.38",
-    "boto3-stubs[bedrock-runtime,dynamodb]~=1.37.38",
-    "opentelemetry-proto~=1.31.1",    
-]
+license = { text = "Apache-2.0" }
+dependencies = ["boto3~=1.37.38"]
 authors = [
-  {name = "Otto Kruse", email = "ottokrus@amazon.nl"},
-  {name = "Ryan French", email = "ryanjfre@amazon.co.uk"},
-  {name = "Mihai Radulescu Kobler", email = "kobler@amazon.de"},
-  {name = "Rui Costa", email = "ruicos@amazon.com"},
+    { name = "Otto Kruse", email = "ottokrus@amazon.nl" },
+    { name = "Ryan French", email = "ryanjfre@amazon.co.uk" },
+    { name = "Mihai Radulescu Kobler", email = "kobler@amazon.de" },
+    { name = "Rui Costa", email = "ruicos@amazon.com" },
 ]
 
 [project.urls]
@@ -31,18 +34,18 @@ authors = [
 run-agent = [
     "flask~=3.1.0",
     "gunicorn~=23.0.0",
+    "opentelemetry-proto~=1.31.1",
     "pydantic~=2.10.6",
 ]
-evaluate = [
-    "nltk~=3.9.1",
-    "scikit-learn~=1.5.1",
-]
+evaluate = ["nltk~=3.9.1", "scikit-learn~=1.5.1"]
 all = [
+    "boto3-stubs[bedrock-runtime,dynamodb]~=1.37.38",
     "flask~=3.1.0",
-    "gunicorn~=23.0.0",
     "gradio~=5.23.3",
+    "gunicorn~=23.0.0",
     "ipython~=8.30.0",
     "nltk~=3.9.1",
+    "opentelemetry-proto~=1.31.1",
     "opentelemetry-proto~=1.31.1",
     "pandas~=2.2.2",
     "pydantic~=2.10.6",
@@ -58,4 +61,11 @@ generative_ai_toolkit = ["tests/*"]
 
 [tool.ruff]
 lint.select = ["F", "E", "W", "C", "N", "I", "PL", "UP", "B"]
-lint.ignore = ["PLR0912", "PLR0913", "PLR0915", "PLR2004", "C901", "E501"] # todo: tighten
+lint.ignore = [
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "PLR2004",
+    "C901",
+    "E501",
+] # todo: tighten

--- a/src/generative_ai_toolkit/test/mock.py
+++ b/src/generative_ai_toolkit/test/mock.py
@@ -12,9 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+import json
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, Unpack
+from functools import cached_property
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NotRequired,
+    TypedDict,
+    Unpack,
+    cast,
+)
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -24,10 +35,14 @@ from generative_ai_toolkit.tracer import BaseTracer
 from generative_ai_toolkit.tracer.trace import Trace
 
 if TYPE_CHECKING:
+    from botocore.eventstream import EventStream
     from mypy_boto3_bedrock_runtime.type_defs import (
         ContentBlockOutputTypeDef,
         ConverseRequestTypeDef,
         ConverseResponseTypeDef,
+        ConverseStreamOutputTypeDef,
+        ConverseStreamRequestTypeDef,
+        ConverseStreamResponseTypeDef,
     )
 
 
@@ -42,8 +57,12 @@ RealResponse = Literal["RealResponse"]
 
 class MockBedrockConverse:
     def __init__(self, session: boto3.session.Session | None = None) -> None:
-        self.real_client = (session or boto3).client("bedrock-runtime")
+        self._session = session
         self.mock_responses: list[ConverseResponseTypeDef | RealResponse] = []
+
+    @cached_property
+    def real_client(self):
+        return (self._session or boto3).client("bedrock-runtime")
 
     def reset(self):
         self.mock_responses = []
@@ -53,16 +72,98 @@ class MockBedrockConverse:
     ) -> "ConverseResponseTypeDef":
         if len(self.mock_responses) == 0:
             raise RuntimeError(
-                f"Exhausted all mock responses, but need to reply to message: {kwargs.get("messages", [])[-1]}"
+                f"Exhausted all mock responses, but need to reply to message: {kwargs.get('messages', [])[-1]}"
             )
         response, *self.mock_responses = self.mock_responses
         if response == "RealResponse":
             response = self.real_client.converse(**kwargs)
         return response
 
+    def _converse_stream(self, **kwargs: Unpack["ConverseStreamRequestTypeDef"]):
+        if len(self.mock_responses) == 0:
+            raise RuntimeError(
+                f"Exhausted all mock responses, but need to reply to message: {kwargs.get('messages', [])[-1]}"
+            )
+        response, *self.mock_responses = self.mock_responses
+        if response == "RealResponse":
+            response = self.real_client.converse_stream(**kwargs)
+        else:
+            response = self._response_as_stream(response)
+        return response
+
+    def _response_as_stream(self, response: "ConverseResponseTypeDef"):
+        def event_stream():
+            has_tool_output = False
+            output = response["output"]
+            if output and "message" in output:
+                for index, content in enumerate(output["message"]["content"]):
+                    if "toolUse" in content:
+                        has_tool_output = True
+                        yield {
+                            "contentBlockStart": {
+                                "start": {
+                                    "toolUse": {
+                                        "toolUseId": content["toolUse"].pop(
+                                            "toolUseId"
+                                        ),
+                                        "name": content["toolUse"].pop("name"),
+                                    }
+                                },
+                                "contentBlockIndex": index,
+                            }
+                        }
+                        content["toolUse"]["input"] = json.dumps(content["toolUse"]["input"])  # type: ignore
+                    elif "reasoningContent" in content:
+                        content["reasoningContent"] = content["reasoningContent"]["reasoningText"]  # type: ignore
+                    yield {"messageStart": {"role": "assistant"}}
+                    yield {
+                        "contentBlockDelta": {
+                            "delta": content,
+                            "contentBlockIndex": index,
+                        }
+                    }
+                    yield {"contentBlockStop": {"contentBlockIndex": index}}
+            yield {
+                "messageStop": {
+                    "stopReason": "tool_use" if has_tool_output else "end_turn"
+                }
+            }
+            yield {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 431,
+                        "outputTokens": 168,
+                        "totalTokens": 599,
+                    },
+                    "metrics": {"latencyMs": 4600},
+                }
+            }
+
+        request_id = uuid4()
+        stream_response: ConverseStreamResponseTypeDef = {
+            "ResponseMetadata": {
+                "RequestId": request_id.hex,
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "date": datetime.now(UTC).strftime(
+                        "%a, %d %b %Y %H:%M:%S GMT"  # Tue, 11 Mar 2025 13:58:48 GMT
+                    ),
+                    "content-type": "application/vnd.amazon.eventstream",
+                    "transfer-encoding": "chunked",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": request_id.hex,
+                    "x-mocked-response": "true",
+                },
+                "RetryAttempts": 0,
+            },
+            "stream": cast("EventStream[ConverseStreamOutputTypeDef]", event_stream()),
+        }
+        return stream_response
+
     def client(self):
         mock_client = Mock(name="MockClient")
         mock_client.converse = self._converse
+        mock_client.converse_stream = self._converse_stream
         return mock_client
 
     def session(self):
@@ -113,12 +214,32 @@ class MockBedrockConverse:
         self,
         tool_use_output: Sequence[ToolUseOutput] = (),
         text_output: Sequence[str] = (),
+        reasoning_output: Sequence[str] = (),
     ):
         tool_uses: list[ContentBlockOutputTypeDef] = [
             {"toolUse": {"toolUseId": uuid4().hex, **t}} for t in tool_use_output
         ]
         texts: list[ContentBlockOutputTypeDef] = [{"text": t} for t in text_output]
-        self.mock_responses.append(self._get_raw_response([*tool_uses, *texts]))
+        reasoning_outputs: list[ContentBlockOutputTypeDef] = [
+            {
+                "reasoningContent": {
+                    "reasoningText": {
+                        "text": t,
+                        "signature": hashlib.sha256(t.encode()).hexdigest(),
+                    }
+                }
+            }
+            for t in reasoning_output
+        ]
+        self.mock_responses.append(
+            self._get_raw_response(
+                [
+                    *reasoning_outputs,
+                    *texts,
+                    *tool_uses,
+                ]
+            )
+        )
 
     def add_real_response(self):
         self.mock_responses.append("RealResponse")
@@ -135,6 +256,7 @@ class LlmInvocationTracer(BaseTracer):
             if not output:
                 return
             texts = []
+            reasoning_texts = []
             tool_uses = []
             for msg in output["message"]["content"]:
                 if "toolUse" in msg:
@@ -146,4 +268,9 @@ class LlmInvocationTracer(BaseTracer):
                     )
                 elif "text" in msg:
                     texts.append(msg["text"])
-            print(f"add_output(text_output={texts},tool_use_output={tool_uses})")
+                elif "reasoningContent" in msg:
+                    if "reasoningText" in msg["reasoningContent"]:
+                        reasoning_texts.append(msg["reasoningContent"]["reasoningText"])
+            print(
+                f"add_output(text_output={texts},tool_use_output={tool_uses}),reasoning_output={reasoning_texts}"
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 import pytest
 from sample_agent_1 import sample_agent_1
 from sample_agent_2 import sample_agent_2
@@ -35,3 +37,427 @@ def mock_agent_1(mock_bedrock_converse):
 @pytest.fixture
 def mock_agent_2(mock_bedrock_converse):
     yield sample_agent_2(session=mock_bedrock_converse.session())
+
+
+@pytest.fixture
+def mock_bedrock_converse_stream_spaghetti_recipe_session():
+    mock_client = MagicMock(name="MockClient")
+    mock_session = MagicMock(name="MockSession")
+    mock_session.client.return_value = mock_client
+
+    def response_stream_1():
+        yield from [
+            {"messageStart": {"role": "assistant"}},
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "The"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " user"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " is"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " asking"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " for"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " a"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " recipe for"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " Spagh"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "etti Carbonara"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": ". I"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " have"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " a"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " tool"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " available"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " calle"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "d `"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "get"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "_recipe` that"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " can provide recipes"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "."}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "\n\nThe"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " require"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "d parameter"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " for"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " this function"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " is:"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "\n-"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " dish: The name"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " of the dish to"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " get a recipe for"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "\n\nIn"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " this"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " case, the dish"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": ' is "S'}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "paghetti"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": ' Carbonara". This'}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " is clearly"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " stated in the user"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": "'s request,"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " so I"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " can call"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " the function"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " with this"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"text": " parameter."}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "reasoningContent": {
+                            "signature": "ErcBCkgIAxABGAIiQGe2vlYmGavCTzCi6P+Ur23sKQwAgQ1SXGV+Qo++w+vr2Rwn1mCyu706GfqjmKp7lx6CnFfHBJj3fFp7kTlJB6MSDGLA/3wQ6NXSnYVtPxoM1TWYaoh7l8fbOTRHIjCQkiTU4Lz3b2j/VCc0jUJoY6kAr0XPv4HYlrof3Xtx9Bc46guGHv/H35kJVfQwhowqHRuvQD9PFtZHu35tnx3VNZagLfRzPeK+MFxzER+y"
+                        }
+                    },
+                    "contentBlockIndex": 0,
+                }
+            },
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": "I can"}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"text": " help"}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"text": " you"}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"text": " with"}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"text": " a"}, "contentBlockIndex": 1}},
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": " recipe for S"},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": "paghetti"},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": " Carbonara!"},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": " Let me get"},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {"contentBlockDelta": {"delta": {"text": " that"}, "contentBlockIndex": 1}},
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": " for you."},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+                            "name": "get_recipe",
+                        }
+                    },
+                    "contentBlockIndex": 2,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": ""}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": '{"dish"'}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": ': "Spaghet'}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": "ti Car"}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": 'bonara"}'}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {"contentBlockStop": {"contentBlockIndex": 2}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 431,
+                        "outputTokens": 168,
+                        "totalTokens": 599,
+                    },
+                    "metrics": {"latencyMs": 4600},
+                }
+            },
+        ]
+
+    def response_stream_2():
+        yield from [
+            {"messageStart": {"role": "assistant"}},
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": "Here is the recipe bla bla"},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 431,
+                        "outputTokens": 168,
+                        "totalTokens": 599,
+                    },
+                    "metrics": {"latencyMs": 4600},
+                }
+            },
+        ]
+
+    response_streams = [response_stream_1(), response_stream_2()]
+
+    def converse_stream(*args, **kwargs):
+        return {
+            "ResponseMetadata": {
+                "RequestId": "16642fc8-2ac3-43fd-bcea-5779911b54fd",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "date": "Mon, 05 May 2025 10:49:44 GMT",
+                    "content-type": "application/vnd.amazon.eventstream",
+                    "transfer-encoding": "chunked",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": "16642fc8-2ac3-43fd-bcea-5779911b54fd",
+                },
+                "RetryAttempts": 0,
+            },
+            "stream": response_streams.pop(0),
+        }
+
+    mock_client.converse_stream = converse_stream
+    yield mock_session
+    if response_streams:
+        raise Exception(f"Unconsumed response streams left! {response_streams}")

--- a/tests/unit/test_converse_reasoning.py
+++ b/tests/unit/test_converse_reasoning.py
@@ -1,0 +1,338 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from generative_ai_toolkit.agent.agent import BedrockConverseAgent
+
+
+def test_converse_stream_with_manual_mock(
+    mock_bedrock_converse_stream_spaghetti_recipe_session,
+):
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+        session=mock_bedrock_converse_stream_spaghetti_recipe_session,
+        additional_model_request_fields={
+            "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    def get_recipe(dish: str):
+        """
+        Get a recipe for the user
+
+        Parameters
+        ------
+        dish: str
+          The name of the dish to get a recipe for
+        """
+        return "Eggs, panceta, spaghetti, olive oil, good luck"
+
+    agent.register_tool(get_recipe)
+
+    res = agent.converse_stream("How should I make Spaghetti Carbonara?")
+
+    expected = textwrap.dedent(
+        """
+        <thinking>
+        The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.
+
+        The required parameter for this function is:
+        - dish: The name of the dish to get a recipe for
+
+        In this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user's request, so I can call the function with this parameter.
+        </thinking>
+
+        I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
+        Here is the recipe bla bla
+        """
+    ).lstrip()
+
+    assert "".join(res) == expected
+
+    assert agent.messages == [
+        {
+            "role": "user",
+            "content": [{"text": "How should I make Spaghetti Carbonara?"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": 'The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.\n\nThe required parameter for this function is:\n- dish: The name of the dish to get a recipe for\n\nIn this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user\'s request, so I can call the function with this parameter.',
+                            "signature": "ErcBCkgIAxABGAIiQGe2vlYmGavCTzCi6P+Ur23sKQwAgQ1SXGV+Qo++w+vr2Rwn1mCyu706GfqjmKp7lx6CnFfHBJj3fFp7kTlJB6MSDGLA/3wQ6NXSnYVtPxoM1TWYaoh7l8fbOTRHIjCQkiTU4Lz3b2j/VCc0jUJoY6kAr0XPv4HYlrof3Xtx9Bc46guGHv/H35kJVfQwhowqHRuvQD9PFtZHu35tnx3VNZagLfRzPeK+MFxzER+y",
+                        }
+                    }
+                },
+                {
+                    "text": "I can help you with a recipe for Spaghetti Carbonara! Let me get that for you."
+                },
+                {
+                    "toolUse": {
+                        "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+                        "name": "get_recipe",
+                        "input": {"dish": "Spaghetti Carbonara"},
+                    }
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+                        "status": "success",
+                        "content": [
+                            {
+                                "json": {
+                                    "toolResponse": "Eggs, panceta, spaghetti, olive oil, good luck"
+                                }
+                            }
+                        ],
+                    }
+                }
+            ],
+        },
+        {
+            "content": [
+                {
+                    "text": "Here is the recipe bla bla",
+                },
+            ],
+            "role": "assistant",
+        },
+    ]
+
+
+def test_converse_stream_with_mock(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+        session=mock_bedrock_converse.session(),
+        additional_model_request_fields={
+            "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    def get_recipe(dish: str):
+        """
+        Get a recipe for the user
+
+        Parameters
+        ------
+        dish: str
+          The name of the dish to get a recipe for
+        """
+        return "Eggs, panceta, spaghetti, olive oil, good luck"
+
+    agent.register_tool(get_recipe)
+
+    mock_bedrock_converse.add_output(
+        reasoning_output=[
+            'The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.\n\nThe required parameter for this function is:\n- dish: The name of the dish to get a recipe for\n\nIn this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user\'s request, so I can call the function with this parameter.',
+        ],
+        text_output=[
+            "I can help you with a recipe for Spaghetti Carbonara! Let me get that for you."
+        ],
+        tool_use_output=[
+            {
+                "name": "get_recipe",
+                "input": {"dish": "Spaghetti Carbonara"},
+                "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+            }
+        ],
+    )
+    mock_bedrock_converse.add_output(text_output=["Here is the recipe bla bla"])
+
+    res = agent.converse_stream("How should I make Spaghetti Carbonara?")
+
+    expected = textwrap.dedent(
+        """
+        <thinking>
+        The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.
+
+        The required parameter for this function is:
+        - dish: The name of the dish to get a recipe for
+
+        In this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user's request, so I can call the function with this parameter.
+        </thinking>
+
+        I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
+        Here is the recipe bla bla
+        """
+    ).lstrip()
+
+    assert "".join(res) == expected
+
+    assert agent.messages == [
+        {
+            "role": "user",
+            "content": [{"text": "How should I make Spaghetti Carbonara?"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": 'The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.\n\nThe required parameter for this function is:\n- dish: The name of the dish to get a recipe for\n\nIn this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user\'s request, so I can call the function with this parameter.',
+                            "signature": "4f5bb65b0c12f9c26d1c953063eb8595f3d45fbbe9ba6f123cc234e74c71ba94",
+                        }
+                    }
+                },
+                {
+                    "text": "I can help you with a recipe for Spaghetti Carbonara! Let me get that for you."
+                },
+                {
+                    "toolUse": {
+                        "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+                        "name": "get_recipe",
+                        "input": {"dish": "Spaghetti Carbonara"},
+                    }
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+                        "status": "success",
+                        "content": [
+                            {
+                                "json": {
+                                    "toolResponse": "Eggs, panceta, spaghetti, olive oil, good luck"
+                                }
+                            }
+                        ],
+                    }
+                }
+            ],
+        },
+        {
+            "content": [
+                {
+                    "text": "Here is the recipe bla bla",
+                },
+            ],
+            "role": "assistant",
+        },
+    ]
+
+
+def test_converse_no_thinking(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+        session=mock_bedrock_converse.session(),
+        additional_model_request_fields={
+            "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+        },
+        include_reasoning_text_within_thinking_tags=False,
+    )
+
+    def get_recipe(dish: str):
+        """
+        Get a recipe for the user
+
+        Parameters
+        ------
+        dish: str
+          The name of the dish to get a recipe for
+        """
+        return "Eggs, panceta, spaghetti, olive oil, good luck"
+
+    agent.register_tool(get_recipe)
+
+    mock_bedrock_converse.add_output(
+        reasoning_output=[
+            'The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.\n\nThe required parameter for this function is:\n- dish: The name of the dish to get a recipe for\n\nIn this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user\'s request, so I can call the function with this parameter.',
+        ],
+        text_output=[
+            "I can help you with a recipe for Spaghetti Carbonara! Let me get that for you."
+        ],
+        tool_use_output=[
+            {
+                "name": "get_recipe",
+                "input": {"dish": "Spaghetti Carbonara"},
+                "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+            }
+        ],
+    )
+    mock_bedrock_converse.add_output(text_output=["Here is the recipe bla bla"])
+
+    res = agent.converse_stream("How should I make Spaghetti Carbonara?")
+
+    expected = textwrap.dedent(
+        """
+        I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
+        Here is the recipe bla bla
+        """
+    ).lstrip()
+
+    assert "".join(res) == expected
+
+
+def test_converse_stream_no_thinking(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
+        session=mock_bedrock_converse.session(),
+        additional_model_request_fields={
+            "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
+        },
+        include_reasoning_text_within_thinking_tags=False,
+    )
+
+    def get_recipe(dish: str):
+        """
+        Get a recipe for the user
+
+        Parameters
+        ------
+        dish: str
+          The name of the dish to get a recipe for
+        """
+        return "Eggs, panceta, spaghetti, olive oil, good luck"
+
+    agent.register_tool(get_recipe)
+
+    mock_bedrock_converse.add_output(
+        reasoning_output=[
+            'The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.\n\nThe required parameter for this function is:\n- dish: The name of the dish to get a recipe for\n\nIn this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user\'s request, so I can call the function with this parameter.',
+        ],
+        text_output=[
+            "I can help you with a recipe for Spaghetti Carbonara! Let me get that for you."
+        ],
+        tool_use_output=[
+            {
+                "name": "get_recipe",
+                "input": {"dish": "Spaghetti Carbonara"},
+                "toolUseId": "tooluse_W0JfmJb6Si61QMXXy0ynYw",
+            }
+        ],
+    )
+    mock_bedrock_converse.add_output(text_output=["Here is the recipe bla bla"])
+
+    res = agent.converse_stream("How should I make Spaghetti Carbonara?")
+
+    expected = textwrap.dedent(
+        """
+        I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
+        Here is the recipe bla bla
+        """
+    ).lstrip()
+
+    assert "".join(res) == expected


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Support reasoning models such as Anthropic Clause Sonnet 3.7

If you want to use reasoning with a model that supports it (e.g. `anthropic.claude-3-7-sonnet-20250219-v1:0`), specify `additional_model_request_fields`:

```python
from generative_ai_toolkit.agent import BedrockConverseAgent

agent = BedrockConverseAgent(
    model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
    additional_model_request_fields={
        "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
    },
)
```

Then, when calling `converse` or `converse_stream`, reasoning texts will be included within `<thinking>` tags in the output:

```python
response = agent.converse("How should I make Spaghetti Carbonara?")
print(response)
```

Would print e.g.:

```
<thinking>
The user is asking for a recipe for Spaghetti Carbonara. I have a tool available called `get_recipe` that can provide recipes.

The required parameter for this function is:
- dish: The name of the dish to get a recipe for

In this case, the dish is "Spaghetti Carbonara". This is clearly stated in the user's request, so I can call the function with this parameter.
</thinking>

I can help you with a recipe for Spaghetti Carbonara! Let me get that for you.
Here is the recipe ...
```

If you do not want to include the reasoning texts in the output, you can turn that off like so:

```python
from generative_ai_toolkit.agent import BedrockConverseAgent

agent = BedrockConverseAgent(
    model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
    additional_model_request_fields={
        "reasoning_config": {"type": "enabled", "budget_tokens": 1024}
    },
    include_reasoning_text_within_thinking_tags=False, # set this to False
)
```

As part of the work of adding reasoning support I made several associated changes:

- Added support for `converse_stream` to the `BedrockConverseMock` (previously it only worked with `converse`)
- Improved the typing of LLM messages in conversation history and agent code. As a result I was able to get rid of all `cast()` statements in the agent code 🎉 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
