### PR TITLE
Use Agent as MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,9 @@ agent = BedrockConverseAgent(
 mcp_client = McpClient(agent)
 ```
 
-When you instantiate the `McpClient` it will look for an MCP configuration (`mcp.json`) to load MCP servers. By default it searches for `mcp.json` in the current working directory first, and then in `~/.aws/amazonq/mcp.json` (which is the Amazon Q config path).
+When you instantiate the `McpClient` it will look for an MCP configuration (`mcp.json`) to load MCP servers. All MCP servers from the configuration will be added as tools to the agent automatically.
+
+To load the configuration, `mcp.json` in the current working directory is tried first, and then `~/.aws/amazonq/mcp.json` (which is the Amazon Q config path). If both do not exist, no tools will be added to the agent.
 
 You can also provide the path to `mcp.json` explicitly upon instantiating the McpClient:
 

--- a/README.md
+++ b/README.md
@@ -1632,6 +1632,10 @@ Note: only local MCP servers (that communicate over `stdio`) are supported curre
 
 To chat with your MCP client, call `chat()`. This will start a REPL chat:
 
+```python
+mcp_client.chat()
+```
+
 ```
 MCP server configuration loaded: mcp.json
 
@@ -1658,12 +1662,23 @@ Assistant: Goodbye!
 You can customize the chat loop by providing your own loop function:
 
 ```python
-def chat_loop(agent: Agent):
+def my_chat_loop(agent: Agent):
     while True:
-        user_input = input("User: ")
+        user_input = input("Awesome user: ")
         if not user_input:
             break
-        for chunk in agent.converse_stream("How's the weather currently?"):
+        for chunk in agent.converse_stream(user_input):
             print(chunk, end="", flush=True)
         print()
+```
+
+And then:
+
+```python
+mcp_client.chat(chat_loop=my_chat_loop)
+```
+
+```
+Awesome user:
+
 ```

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ As you can see, tools that you've registered will be invoked automatically by th
 
 #### Other tools
 
-If you don't want to register a Python function as tool, but have a tool with toolspec ready, you can also use it directly, as long as your tool satisfies the `Tool` protocol, i.e. has this shape:
+If you don't want to register a Python function as tool, but have a tool with tool spec ready, you can also use it directly, as long as your tool satisfies the `Tool` protocol, i.e. has this shape:
 
 ```python
 from typing import Any
@@ -329,6 +329,32 @@ class MyTool:
         return "Tool response"
 
 agent.register_tool(MyTool())
+```
+
+It's also possible to provide the tool spec explicitly alongside your plain Python function:
+
+```python
+agent.register_tool(
+    lambda preferred_weather: f"Not {preferred_weather}",
+    tool_spec={
+        "name": "get_weather",
+        "description": "Gets the current weather",
+        "inputSchema": {
+            "json": {
+                "type": "object",
+                "properties": {
+                    "preferred_weather": {
+                        "type": "string",
+                        "description": "The preferred weather",
+                    },
+                },
+                "required": [
+                    "preferred_weather",
+                ],
+            }
+        },
+    },
+)
 ```
 
 #### Tools override

--- a/README.md
+++ b/README.md
@@ -1591,13 +1591,14 @@ You can turn your agent into an MCP client easily like so:
 ```python
 from generative_ai_toolkit.agent import BedrockConverseAgent
 from generative_ai_toolkit.mcp.client import McpClient
-from generative_ai_toolkit.tracer import HumanReadableTracer
 
+# Create agent:
 agent = BedrockConverseAgent(
     system_prompt="You are a helpful assistant",
     model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
 )
 
+# Turn agent into MCP client:
 mcp_client = McpClient(agent)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ all = [
     "gunicorn~=23.0.0",
     "ipython~=8.30.0",
     "nltk~=3.9.1",
+    "mcp~=1.8.0",
     "opentelemetry-proto~=1.31.1",
     "opentelemetry-proto~=1.31.1",
     "pandas~=2.2.2",

--- a/src/generative_ai_toolkit/mcp/client.py
+++ b/src/generative_ai_toolkit/mcp/client.py
@@ -1,0 +1,228 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import contextlib
+import json
+import os
+from collections.abc import Callable, Sequence
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from pydantic import BaseModel, Field, PrivateAttr
+
+from generative_ai_toolkit.agent.agent import Agent
+
+if TYPE_CHECKING:
+    from generative_ai_toolkit.agent.tool import ToolSpecificationTypeDef
+
+CONFIG_PATHS = [
+    Path(os.curdir) / "mcp.json",
+    os.path.expanduser("~/.aws/amazonq/mcp.json"),
+]
+
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+class McpServerConfig(BaseModel):
+    command: str
+    env: dict[str, str] = Field({})
+    args: list[str] = Field([])
+
+
+class McpClientConfig(BaseModel):
+    mcpServers: dict[str, McpServerConfig]  # noqa: N815
+    _path: str = PrivateAttr(default="")
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @classmethod
+    def from_file(cls, path: str | os.PathLike) -> "McpClientConfig":
+        with open(path) as f:
+            data = json.load(f)
+        instance = cls(**data)
+        instance._path = str(path)
+        return instance
+
+
+class McpClient:
+
+    def __init__(
+        self, agent: Agent, client_config_path: os.PathLike | str | None = None
+    ):
+        self.agent = agent
+        self.config = self.load_client_config(
+            [client_config_path] if client_config_path else None
+        )
+
+    async def connect_mcp_servers(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        exit_stack: contextlib.AsyncExitStack,
+    ):
+        coros = [
+            self.connect_to_mcp_server(
+                exit_stack=exit_stack,
+                command=params.command,
+                args=params.args,
+                env=params.env,
+            )
+            for params in self.config.mcpServers.values()
+        ]
+
+        def make_tool_func(session: ClientSession, tool_name: str):
+            def func(**kwargs):
+                fut = asyncio.run_coroutine_threadsafe(
+                    session.call_tool(
+                        tool_name,
+                        arguments=kwargs,
+                        read_timeout_seconds=timedelta(seconds=30),
+                    ),
+                    loop,
+                )
+
+                res = fut.result().model_dump()
+                self.agent.tracer.current_trace.add_attribute("ai.mcp.response", res)
+                return res["content"][0]["text"]
+
+            return func
+
+        for session, tools in await asyncio.gather(*coros):
+            for tool in tools:
+                tool_spec: ToolSpecificationTypeDef = {
+                    "name": tool.name,
+                    "description": tool.description or "",
+                    "inputSchema": {
+                        "json": {
+                            "type": "object",
+                            "properties": tool.inputSchema["properties"],
+                        }
+                    },
+                }
+
+                self.agent.register_tool(
+                    make_tool_func(session, tool.name),
+                    tool_spec=tool_spec,
+                )
+
+    async def connect_to_mcp_server(
+        self,
+        exit_stack: contextlib.AsyncExitStack,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ):
+        server_params = StdioServerParameters(command=command, args=args or [], env=env)
+
+        stdio_transport = await exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        stdio, write = stdio_transport
+        session = await exit_stack.enter_async_context(ClientSession(stdio, write))
+
+        await session.initialize()
+        response = await session.list_tools()
+        tools = response.tools
+        return session, tools
+
+    def chat(
+        self,
+        chat_loop: Callable[[asyncio.AbstractEventLoop, Agent], Any] | None = None,
+    ):
+        asyncio.run(self._chat(chat_loop))
+
+    async def _chat(
+        self,
+        chat_loop: Callable[[asyncio.AbstractEventLoop, Agent], Any] | None = None,
+    ):
+        async with contextlib.AsyncExitStack() as exit_stack:
+            loop = asyncio.get_running_loop()
+            await self.connect_mcp_servers(loop, exit_stack)
+            await loop.run_in_executor(
+                None, chat_loop or self._default_chat_loop, loop, self.agent
+            )
+
+            # Unfortunately I have to do this because the exit stack always hangs on exit,
+            # which blocks the program from exiting (MacOs Sequoia 15.4.1, Python 3.12).
+            # Pretty sure this is a bug in the mcp library, potentially this one:
+            # https://github.com/modelcontextprotocol/python-sdk/issues/547
+            async def exit_soon():
+                await asyncio.sleep(1)
+                os._exit(0)
+
+            loop.create_task(exit_soon())
+            await exit_stack.aclose()
+
+    @staticmethod
+    def _default_chat_loop(loop: asyncio.AbstractEventLoop, agent: Agent):
+        """
+        Chat with the MCP client
+
+        This is meant as a testing utility. Any serious MCP client would likely customize this implementation.
+        """
+
+        print(
+            "\nMCP client ready. Type '/q' to quit. Type /t to list the available tools.\n"
+        )
+        while True:
+            user_input = input("You: ").strip()
+            if not user_input or user_input == "/q":
+                print("Assistant: Goodbye!")
+                break
+
+            if user_input.strip() == "/t":
+                print("\nListing available tools:\n")
+                for tool in agent.tools.values():
+                    print(f"  {tool.tool_spec["name"]}")
+                    print(f"  {"_" * len(tool.tool_spec["name"])}\n")
+                    for line in (
+                        tool.tool_spec.get("description", "").strip().splitlines()
+                    ):
+                        print(f"    {line}")
+                    print()
+                print()
+                continue
+
+            for index, fragment in enumerate(agent.converse_stream(user_input)):
+                if not index:
+                    print("Assistant: ", end="", flush=True)
+                if fragment.strip() == "<thinking>":
+                    print(DIM, end="", flush=True)
+                print(fragment, end="", flush=True)
+                if fragment.strip() == "</thinking>":
+                    print(RESET, end="", flush=True)
+            print()
+
+    @staticmethod
+    def load_client_config(
+        paths: Sequence[str | os.PathLike] | None = None,
+    ) -> McpClientConfig:
+        for path in paths or CONFIG_PATHS:
+            try:
+                cfg = McpClientConfig.from_file(path)
+            except FileNotFoundError:
+                if not paths:
+                    # Using default locations
+                    continue
+            else:
+                break
+        else:
+            return McpClientConfig(mcpServers={})
+        return cfg

--- a/src/generative_ai_toolkit/mcp/client.py
+++ b/src/generative_ai_toolkit/mcp/client.py
@@ -72,7 +72,9 @@ class McpClient:
             [client_config_path] if client_config_path else None
         )
         # Enable the MCP config to have relative paths:
-        os.chdir(os.path.dirname(self.config.path))
+        config_dir = os.path.dirname(self.config.path)
+        if config_dir:
+            os.chdir(config_dir)
 
     async def connect_mcp_servers(
         self,
@@ -141,22 +143,22 @@ class McpClient:
 
     def chat(
         self,
-        chat_loop: Callable[[asyncio.AbstractEventLoop, Agent], Any] | None = None,
+        chat_loop: Callable[[Agent], Any] | None = None,
     ):
         asyncio.run(self._chat(chat_loop))
 
     async def _chat(
         self,
-        chat_loop: Callable[[asyncio.AbstractEventLoop, Agent], Any] | None = None,
+        chat_loop: Callable[[Agent], Any] | None = None,
     ):
         async with contextlib.AsyncExitStack() as exit_stack:
             loop = asyncio.get_running_loop()
             await self.connect_mcp_servers(loop, exit_stack)
             await loop.run_in_executor(
-                None, chat_loop or self._default_chat_loop, loop, self.agent
+                None, chat_loop or self._default_chat_loop, self.agent
             )
 
-    def _default_chat_loop(self, loop: asyncio.AbstractEventLoop, agent: Agent):
+    def _default_chat_loop(self, agent: Agent):
         """
         Chat with the MCP client
 
@@ -165,7 +167,7 @@ class McpClient:
 
         print(f"MCP server configuration loaded: {self.config.path}")
         print(
-            "\nMCP client ready. Type '/q' to quit. Type /t to list the available tools.\n"
+            "\nMCP client ready. Type /q to quit. Type /t to list the available tools.\n"
         )
         while True:
             user_input = input("You: ").strip()

--- a/src/generative_ai_toolkit/mcp/client.py
+++ b/src/generative_ai_toolkit/mcp/client.py
@@ -71,6 +71,8 @@ class McpClient:
         self.config = self.load_client_config(
             [client_config_path] if client_config_path else None
         )
+        # Enable the MCP config to have relative paths:
+        os.chdir(os.path.dirname(self.config.path))
 
     async def connect_mcp_servers(
         self,

--- a/src/generative_ai_toolkit/test/mock.py
+++ b/src/generative_ai_toolkit/test/mock.py
@@ -217,7 +217,8 @@ class MockBedrockConverse:
         reasoning_output: Sequence[str] = (),
     ):
         tool_uses: list[ContentBlockOutputTypeDef] = [
-            {"toolUse": {"toolUseId": uuid4().hex, **t}} for t in tool_use_output
+            {"toolUse": {"toolUseId": uuid4().hex, "input": {}, **t}}
+            for t in tool_use_output
         ]
         texts: list[ContentBlockOutputTypeDef] = [{"text": t} for t in text_output]
         reasoning_outputs: list[ContentBlockOutputTypeDef] = [

--- a/tests/unit/mcp.json
+++ b/tests/unit/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "WeatherForecasts": {
+      "command": "python3",
+      "args": ["mcp_server_get_weather.py"],
+      "env": {
+        "WEATHER": "Sunny"
+      }
+    }
+  }
+}

--- a/tests/unit/mcp.json
+++ b/tests/unit/mcp.json
@@ -4,7 +4,8 @@
       "command": "python3",
       "args": ["mcp_server_get_weather.py"],
       "env": {
-        "WEATHER": "Sunny"
+        "WEATHER": "Sunny",
+        "FASTMCP_LOG_LEVEL": "ERROR"
       }
     }
   }

--- a/tests/unit/mcp_server_get_weather.py
+++ b/tests/unit/mcp_server_get_weather.py
@@ -8,7 +8,7 @@ mcp = FastMCP(
         """
         # Weather Information
 
-        Provides information on current weather, as well as forecasts.
+        Provides information on current weather.
         """
     ),
 )

--- a/tests/unit/mcp_server_get_weather.py
+++ b/tests/unit/mcp_server_get_weather.py
@@ -1,0 +1,31 @@
+import textwrap
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(
+    "Weather Information",
+    instructions=textwrap.dedent(
+        """
+        # Weather Information
+
+        Provides information on current weather, as well as forecasts.
+        """
+    ),
+)
+
+
+@mcp.tool(
+    description=textwrap.dedent(
+        """
+        Gets the current weather for the user.
+
+        This tool is already aware of the user's location, so you don't need to provide it.
+        """
+    )
+)
+async def current_weather():
+    return "Sunny, 27 degrees (C)."
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from generative_ai_toolkit.agent import BedrockConverseAgent
+from generative_ai_toolkit.mcp.client import McpClient
+
+
+HERE = Path(__file__).parent
+
+
+def test_mcp_client(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="dummy",
+    )
+
+    mcp_client = McpClient(agent, client_config_path=str(HERE / "mcp.json"))
+    assert mcp_client.config.model_dump() == {
+        "mcpServers": {
+            "WeatherForecasts": {
+                "args": [
+                    "mcp_server_get_weather.py",
+                ],
+                "command": "python3",
+                "env": {
+                    "WEATHER": "Sunny",
+                },
+            },
+        },
+    }
+
+    #####
+    # Unfortunately I have to comment the below tests out for now,
+    # as a suspected bug in the MCP library hangs the test
+    # See details in src/generative_ai_toolkit/mcp/client.py
+    #####
+
+    # def chat_loop(loop, agent):
+    #     agent.converse("What is the weather currently?")
+
+    # mock_bedrock_converse.add_output(tool_use_output=[{"name": "current_weather"}])
+    # mock_bedrock_converse.add_output(text_output=["Sunny"])
+
+    # mcp_client.chat(chat_loop=chat_loop)

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -14,11 +14,9 @@
 
 from pathlib import Path
 
-
 from generative_ai_toolkit.agent import Agent, BedrockConverseAgent
 from generative_ai_toolkit.mcp.client import McpClient
 from generative_ai_toolkit.test import Expect
-
 
 HERE = Path(__file__).parent
 

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asyncio import AbstractEventLoop
 from pathlib import Path
 
 
@@ -45,7 +44,7 @@ def test_mcp_client(mock_bedrock_converse):
         },
     }
 
-    def chat_loop(loop: AbstractEventLoop, agent: Agent):
+    def chat_loop(agent: Agent):
         agent.converse("What is the weather currently?")
 
     mock_bedrock_converse.add_output(tool_use_output=[{"name": "current_weather"}])


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added basic support to turn your agent into an MCP client.

You can turn your agent into an MCP client easily like so:

```python
from generative_ai_toolkit.agent import BedrockConverseAgent
from generative_ai_toolkit.mcp.client import McpClient

# Create agent:
agent = BedrockConverseAgent(
    system_prompt="You are a helpful assistant",
    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
)

# Turn agent into MCP client:
mcp_client = McpClient(agent)
```

When you instantiate the `McpClient` it will look for an MCP configuration (`mcp.json`) to load MCP servers. By default it searches for `mcp.json` in the current working directory first, and then in `~/.aws/amazonq/mcp.json` (which is the Amazon Q config path).

You can also provide the path to `mcp.json` explicitly upon instantiating the McpClient:

```python
mcp_client = McpClient(agent, client_config_path="/path/to/mcp.json")
```

The `mcp.json` config follows the same format as Amazon Q MCP config, e.g.:

```json
{
  "mcpServers": {
    "WeatherForecasts": {
      "command": "python3",
      "args": ["mcp_server_get_weather.py"],
      "env": {
        "WEATHER": "Sunny",
        "FASTMCP_LOG_LEVEL": "ERROR"
      }
    }
  }
}
```

Note: only local MCP servers (that communicate over `stdio`) are supported currently.

#### Chat loop

To chat with your MCP client, call `chat()`. This will start a REPL chat:

```python
mcp_client.chat()
```

```
MCP server configuration loaded: mcp.json

MCP client ready. Type /q to quit. Type /t to list the available tools.

You: /t

Listing available tools:

  current_weather
  _______________

    Gets the current weather for the user.

    This tool is already aware of the user's location, so you don't need to provide it.

You: How's the weather?
Assistant: It's currently sunny and 27 degrees Celsius outside.

You: /q
Assistant: Goodbye!
```

You can customize the chat loop by providing your own loop function:

```python
def my_chat_loop(agent: Agent):
    while True:
        user_input = input("Awesome user: ")
        if not user_input:
            break
        for chunk in agent.converse_stream(user_input):
            print(chunk, end="", flush=True)
        print()
```

And then:

```python
mcp_client.chat(chat_loop=my_chat_loop)
```

```
Awesome user:

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
