### PR TITLE
Support using agent as tool to another agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ To fully utilize the Generative AI Toolkit, it’s essential to understand the f
 
 2.1 [Installation](#21-installation)  
 2.2 [Agent Implementation](#22-agent-implementation)  
-2.3 [Tracing](#23-tracing)  
+ 2.2.1 [Chat with agent](#221-chat-with-agent)  
+ 2.2.2 [Conversation history](#222-conversation-history)  
+ 2.2.3 [Reasoning and other Bedrock Converse Arguments](#223-bedrock-converse-arguments)  
+ 2.2.4 [Tools](#224-tools)  
+ 2.2.5 [Multi-agent support](#225-multi-agent-support)  
+ 2.2.6 [Tracing](#226-tracing)  
 2.4 [Evaluation Metrics](#24-evaluation-metrics)  
 2.5 [Repeatable Cases](#25-repeatable-cases)  
 2.6 [Cases with Dynamic Expectations](#26-cases-with-dynamic-expectations)  
@@ -109,7 +114,7 @@ agent = BedrockConverseAgent(
 
 Obviously right now this agent doesn't have any tools yet (we'll add some shortly), but you can already chat with it.
 
-#### Chat with agent
+#### 2.2.1 Chat with agent
 
 Use `converse()` to chat with the agent. You pass the user's input to this function, and it will return the agent's response as string:
 
@@ -118,7 +123,7 @@ response = agent.converse("What's the capital of France?")
 print(response) # "The capital of France is Paris."
 ```
 
-#### Response streaming
+##### Response streaming
 
 You can also use `converse_stream()` to chat with the agent. You pass the user's input to this function, and it will return an iterator that will progressively return the response fragments. You should concatenate these fragments to collect the full response.
 
@@ -138,7 +143,7 @@ The
  Paris.
 ```
 
-#### Conversation history
+#### 2.2.2 Conversation history
 
 The agent maintains the conversation history, so e.g. after the question just asked, this would now work:
 
@@ -149,7 +154,7 @@ print(response) # "Here are some of the major tourist highlights and attractions
 
 By default conversation history is stored in memory only. If you want to use conversation history across different process instantiations, you need conversation history that is persisted to durable storage.
 
-#### Persisting conversation history
+##### Persisting conversation history
 
 You can use the `DynamoDbConversationHistory` class to persist conversations to DynamoDB. Conversation history is maintained per conversation ID. The agent will create a new conversation ID automatically:
 
@@ -184,7 +189,7 @@ response = agent.converse("What are some touristic highlights there?")
 print(response) # "Here are some of the major tourist highlights and attractions in Paris, France:\n\n- Eiffel Tower - One of the most famous monuments ..."
 ```
 
-#### Viewing the conversation history
+##### Viewing the conversation history
 
 You can manually view the conversation history like so:
 
@@ -197,7 +202,7 @@ Conversation history is included automatically in the prompt to the LLM. That is
 
 This is generally how conversations with LLMs work––the LLM has no memory of the current conversation, you need to provide all past messages, including those from the LLM (the "assistant"), as part of your prompt to the LLM.
 
-#### Starting a fresh conversation
+##### Starting a fresh conversation
 
 Calling `agent.reset()` starts a new conversation, with empty conversation history:
 
@@ -210,7 +215,7 @@ print(len(agent.messages)) # 0
 print(agent.conversation_id)  # e.g.: "01J5DQRD864TR3BF314CZK8X5B" (changed)
 ```
 
-#### Bedrock Converse Arguments
+#### 2.2.3 Bedrock Converse Arguments
 
 Upon instantiating the `BedrockConverseAgent` you can pass any arguments that the Bedrock Converse API accepts, and these will be used for all invocations of the Converse API by the agent. You could for example specify usage of [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html):
 
@@ -288,7 +293,7 @@ agent = BedrockConverseAgent(
 )
 ```
 
-#### Tools
+#### 2.2.4 Tools
 
 If you want to give the agent access to tools, you can define them as Python functions, and register them with the agent. Your Python function must have type annotations for input and output, and a docstring like so:
 
@@ -312,7 +317,7 @@ print(response) # Okay, let me get the current weather report for Amsterdam usin
 
 As you can see, tools that you've registered will be invoked automatically by the agent. The output from `converse` is always just a string with the agent's response to the user.
 
-#### Other tools
+##### Other tools
 
 If you don't want to register a Python function as tool, but have a tool with tool spec ready, you can also use it directly, as long as your tool satisfies the `Tool` protocol, i.e. has this shape:
 
@@ -358,7 +363,7 @@ agent.register_tool(
 )
 ```
 
-#### Tools override
+##### Tools override
 
 It's possible to set and override the tool selection when calling converse:
 
@@ -380,7 +385,48 @@ print(response) # Okay, let me check the current weather report for Amsterdam us
 
 Note that this does not force the agent to use the provided tools, it merely makes them available for the agent to use.
 
-### 2.3 Tracing
+#### 2.2.5 Multi-Agent Support
+
+Agents can themselves be used as tool too. This allows you to build hierarchical multi-agent systems, where a supervisor agent can use specialized subordinate agents to delegate tasks to.
+
+To use an agent as a tool, the agent must have a `name` and `description`:
+
+```python
+# Create a specialized weather agent:
+weather_agent = BedrockConverseAgent(
+    model_id="anthropic.claude-3-haiku-20240307-v1:0",
+    system_prompt="You provide the weather forecast for the specified city.",
+    name="transfer_to_weather_agent",  # will be used as the tool name when registered
+    description="Get the weather forecast for a city.",  # will be used as the tool description
+)
+
+# Add tools to the specialized agent:
+def get_weather(city: str):
+    """Gets the weather forecast for the provided city"""
+    return "Sunny"
+
+weather_agent.register_tool(get_weather)
+
+# Create a supervisor agent that uses the specialized agent:
+supervisor = BedrockConverseAgent(
+    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+    system_prompt="You provide users with information about cities they want to visit.",
+)
+
+# Register the specialized agent as a tool with the supervisor:
+supervisor.register_tool(weather_agent)
+
+# The supervisor will delegate to the specialized agent:
+response = supervisor.converse("What's the weather like in Amsterdam?")
+```
+
+Notes:
+
+- More layers of nesting can be added if desired; a subordinate agent can itself be supervisor to its own set of subordinate agents, etc.
+- Each agent maintains its own set of traces that can be inspected independently, making it easy to debug and understand the flow of information through your multi-agent system.
+- The above example is obviously contrived; for a more comprehensive example with multiple specialized agents working together, see [multi_agent.ipynb](/examples/multi_agent.ipynb).
+
+#### 2.2.6 Tracing
 
 You can make `BedrockConverseAgent` log traces of the LLM and tool calls it performs, by providing a tracer class.
 
@@ -413,13 +459,13 @@ Trace(span_name='converse', span_kind='SERVER', trace_id='33185be48ee341d16bf681
 
 That is the root trace of the conversation, that captures user input and agent response. Other traces capture details such as LLM invocations, Tool invocations, usage of conversation history, etc.
 
-#### Available tracers
+##### Available tracers
 
 The Generative AI Toolkit includes several tracers out-of-the-box, e.g. the `DynamoDBTracer` that saves traces to DynamoDB, and the `OtlpTracer` that sends traces to an OpenTelemetry collector (e.g. to forward them to AWS X-Ray).
 
 For a full run-down of all out-of-the-box tracers and how to use them, view [examples/tracing101.ipynb](examples/tracing101.ipynb).
 
-#### Open Telemetry
+##### Open Telemetry
 
 Traces use the [OpenTelemetry "Span" model](https://opentelemetry.io/docs/specs/otel/trace/api/#span). That model works at high level by assigning a unique Trace ID to each incoming request (e.g. over HTTP). All actions that are taken while executing that request, are recorded as "span" and will have a unique Span ID. Span name, start timestamp, end timestamp, are recorded at span level.
 
@@ -463,7 +509,7 @@ In the OpenTelemetry Span model, information such as "the model ID used for the 
 | `ai.agent.response`                                    | The final concatenated response from the agent                                                                                                                                                    |
 | `service.name`                                         | Name of the service, set to the class name of the agent                                                                                                                                           |
 
-#### Viewing traces
+##### Viewing traces
 
 ```python
 for trace in agent.traces:
@@ -538,7 +584,7 @@ Which would print e.g.:
 
 ```
 
-#### Web UI
+##### Web UI
 
 You can view the traces for a conversation using the Generative AI Toolkit Web UI:
 
@@ -560,7 +606,7 @@ Stop the Web UI as follows:
 demo.close()
 ```
 
-#### DynamoDB example
+##### DynamoDB example
 
 As example, here's some traces that were stored with the `DynamoDBTracer`:
 
@@ -568,7 +614,7 @@ As example, here's some traces that were stored with the `DynamoDBTracer`:
 
 In production deployments, you'll likely want to use the `DynamoDBTracer`, so you can listen to the DynamoDB stream as traces are recorded, and run metric evaluations against them (see next section). This way, you can monitor the performance of your agent in production.
 
-#### AWS X-Ray example
+##### AWS X-Ray example
 
 Here's a more elaborate example of a set traces when viewed in AWS X-Ray (you would have used the `OtlpTracer` to send them there):
 

--- a/examples/multi_agent.ipynb
+++ b/examples/multi_agent.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f5dab0de",
+   "metadata": {},
+   "source": [
+    "# Multi-Agent\n",
+    "\n",
+    "This notebook demonstrates how you can use the Generative AI Toolkit to implement a multi-agent architecture.\n",
+    "\n",
+    "In the example here, we'll build an agent whose job it is to give the user information on the city they want to travel to.\n",
+    "\n",
+    "This agent, the supervisor, has two subordinate agents that it can hand tasks to:\n",
+    "\n",
+    "- Weather agent: to get the weather forecast for the city\n",
+    "- Events agents: to get a list of upcoming concerts and other events in the city\n",
+    "\n",
+    "We can implement the multi-agent architecture by simply registering subordinate agents as tools with a higher-level agent. To be able to use an agent as tool, the agent must have a `name` and a `description`. Providing an `input_schema` is optional, but can be used to signal to the supervisor agent that is should send certain fields to the subordinate agent.\n",
+    "\n",
+    "In the example here we just have a 2-level hierarchy: one supervisor, and 2 subordinate agents. You could add more levels if you want; one of the subordinate agents could itself be a supervisor to its own set of subordinate agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11d08ec8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import textwrap\n",
+    "\n",
+    "from generative_ai_toolkit.agent import BedrockConverseAgent\n",
+    "from generative_ai_toolkit.ui import traces_ui"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d4232c",
+   "metadata": {},
+   "source": [
+    "## Weather agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0df1069",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_weather(city: str):\n",
+    "    \"\"\"\n",
+    "    Gets the weather forecast for the provided city\n",
+    "\n",
+    "    Parameters\n",
+    "    ---\n",
+    "    city : string\n",
+    "        The city to get the weather forecast for\n",
+    "    \"\"\"\n",
+    "    return \"Sunny\"\n",
+    "\n",
+    "\n",
+    "weather_agent = BedrockConverseAgent(\n",
+    "    model_id=\"anthropic.claude-3-haiku-20240307-v1:0\",\n",
+    "    system_prompt=\"You provide the weather forecast for the specified city.\",\n",
+    "    name=\"transfer_to_weather_agent\",  # will be used as the name of the tool registration, in the supervisor agent\n",
+    "    description=\"Get the weather forecast for a city.\",  # will be used as the description of the tool registration, in the supervisor agent\n",
+    ")\n",
+    "weather_agent.register_tool(get_weather)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8a8e867",
+   "metadata": {},
+   "source": [
+    "## Events agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e371738",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_events(city: str):\n",
+    "    \"\"\"\n",
+    "    Gets upcoming events (concerts, festivals, etc) in the provided city\n",
+    "\n",
+    "    Parameters\n",
+    "    ---\n",
+    "    city : string\n",
+    "        The city to get the upcoming events for\n",
+    "    \"\"\"\n",
+    "    return [\n",
+    "        {\"name\": \"Nirvana tribute band concert\", \"when\": \"Tomorrow\"},\n",
+    "        {\"name\": \"Food truck festival\", \"when\": \"Coming Saturday\"},\n",
+    "        {\n",
+    "            \"name\": \"Open Museum day -- all museums have free entry\",\n",
+    "            \"when\": \"Coming Sunday\",\n",
+    "        },\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "events_agent = BedrockConverseAgent(\n",
+    "    model_id=\"anthropic.claude-3-haiku-20240307-v1:0\",\n",
+    "    system_prompt=\"You provide the upcoming events for the specified city.\",\n",
+    "    name=\"transfer_to_events_agent\",  # will be used as the name of the tool registration, in the supervisor agent\n",
+    "    description=\"Get the upcoming events for a city.\",  # will be used as the description of the tool registration, in the supervisor agent\n",
+    "    input_schema={\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\n",
+    "            \"city\": {\n",
+    "                \"type\": \"string\",\n",
+    "                \"description\": \"The city to get the upcoming events for\",\n",
+    "            }\n",
+    "        },\n",
+    "        \"required\": [\"city\"],  # By providing this overriding input_schema, we instruct the supervisor agent to pass the `city` field explicitly\n",
+    "    }\n",
+    ")\n",
+    "events_agent.register_tool(get_events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "415af9d9",
+   "metadata": {},
+   "source": [
+    "## Supervisor agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13b1e2a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can likely improve your results, by explicitly telling the supervisor agent that it is part of a multi-agent architecture:\n",
+    "multi_agent_prompt_prefix = textwrap.dedent(\n",
+    "    \"\"\"\n",
+    "    # Multi-Agent Supervisor Context\n",
+    "\n",
+    "    You are the supervisor in a multi-agent system. Your role is to coordinate specialized agents to fulfill complex user requests. Each agent under your supervision is responsible for a distinct capability or domain.\n",
+    "\n",
+    "    When appropriate, delegate sub-tasks to the relevant agents by providing them with focused instructions. Aggregate their responses and synthesize a final answer for the user.\n",
+    "\n",
+    "    Do not reveal the existence of subordinate agents or that task delegation has occurred. Your responses should appear as a single, seamless reply from one intelligent assistant.\n",
+    "    \"\"\"\n",
+    ").strip()\n",
+    "\n",
+    "supervisor = BedrockConverseAgent(\n",
+    "    model_id=\"eu.anthropic.claude-3-7-sonnet-20250219-v1:0\",\n",
+    "    system_prompt=textwrap.dedent(\n",
+    "        \"\"\"\n",
+    "        {multi_agent_prompt_prefix}\n",
+    "\n",
+    "        # Instruction\n",
+    "\n",
+    "        You provide users current information on cities that they may want to visit.\n",
+    "        \"\"\"\n",
+    "    )\n",
+    "    .format(multi_agent_prompt_prefix=multi_agent_prompt_prefix)\n",
+    "    .strip(),\n",
+    ")\n",
+    "supervisor.register_tool(weather_agent)\n",
+    "supervisor.register_tool(events_agent)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4591feff",
+   "metadata": {},
+   "source": [
+    "## Chat with the supervisor agent\n",
+    "\n",
+    "The supervisor agent will use the subordinate agents to help the user:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a97833df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supervisor.reset()\n",
+    "for chunk in supervisor.converse_stream(\n",
+    "    \"I want to visit Amsterdam. Tell me the weather and events please\"\n",
+    "):\n",
+    "    print(chunk, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1098c9a7",
+   "metadata": {},
+   "source": [
+    "## Tracing\n",
+    "\n",
+    "Each agent has its own set of traces that you can inspect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f076f550",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supervisor_ui = traces_ui(supervisor.traces)\n",
+    "supervisor_ui.launch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "995050bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weather_agent_ui = traces_ui(weather_agent.traces)\n",
+    "weather_agent_ui.launch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc2a53db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_agent_ui = traces_ui(events_agent.traces)\n",
+    "events_agent_ui.launch()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/multi_agent.ipynb
+++ b/examples/multi_agent.ipynb
@@ -16,7 +16,7 @@
     "- Weather agent: to get the weather forecast for the city\n",
     "- Events agents: to get a list of upcoming concerts and other events in the city\n",
     "\n",
-    "We can implement the multi-agent architecture by simply registering subordinate agents as tools with a higher-level agent. To be able to use an agent as tool, the agent must have a `name` and a `description`. Providing an `input_schema` is optional, but can be used to signal to the supervisor agent that is should send certain fields to the subordinate agent.\n",
+    "We can implement the multi-agent architecture by simply registering subordinate agents as tools with a higher-level agent. To be able to use an agent as tool, the agent must have a `name` and a `description`. Providing an `input_schema` is optional, but can be used to signal to the supervisor agent that it should send certain fields to the subordinate agent.\n",
     "\n",
     "In the example here we just have a 2-level hierarchy: one supervisor, and 2 subordinate agents. You could add more levels if you want; one of the subordinate agents could itself be a supervisor to its own set of subordinate agents."
    ]

--- a/src/generative_ai_toolkit/agent/agent.py
+++ b/src/generative_ai_toolkit/agent/agent.py
@@ -204,14 +204,14 @@ class Agent(Tool, Protocol):
 
     def invoke(self, *args, **kwargs) -> Any:
         """
-        Invoke the agent as tool. This method is used, when the agent is registered as tool with another agent.
+        Invoke the agent as tool. This method is used, when the agent is registered as a tool with another agent.
         """
         ...
 
     @property
     def tool_spec(self) -> "ToolSpecificationTypeDef":
         """
-        The tool specification of the agent, that allows it to be registered as tool with another agent.
+        The tool specification of the agent, that allows it to be registered as a tool with another agent.
         """
         ...
 

--- a/src/generative_ai_toolkit/agent/agent.py
+++ b/src/generative_ai_toolkit/agent/agent.py
@@ -25,6 +25,7 @@ from typing import (
     Literal,
     Protocol,
     Unpack,
+    runtime_checkable,
 )
 
 import boto3
@@ -64,7 +65,7 @@ if TYPE_CHECKING:
     )
 
 
-class Agent(Protocol):
+class Agent(Tool, Protocol):
     @property
     def model_id(self) -> str:
         """
@@ -201,6 +202,19 @@ class Agent(Protocol):
         """
         ...
 
+    def invoke(self, *args, **kwargs) -> Any:
+        """
+        Invoke the agent as tool. This method is used, when the agent is registered as tool with another agent.
+        """
+        ...
+
+    @property
+    def tool_spec(self) -> "ToolSpecificationTypeDef":
+        """
+        The tool specification of the agent, that allows it to be registered as tool with another agent.
+        """
+        ...
+
 
 class BedrockConverseAgent(Agent):
     _model_id: str
@@ -241,6 +255,9 @@ class BedrockConverseAgent(Agent):
         executor: Executor | None = None,
         tool_result_json_encoder: type[json.JSONEncoder] | None = None,
         include_reasoning_text_within_thinking_tags=True,
+        name: str | None = None,
+        description: str | None = None,
+        input_schema: dict[str, Any] | None = None,
     ) -> None:
         """
         Create an Agent that will use the Bedrock Converse API to operate.
@@ -293,6 +310,12 @@ class BedrockConverseAgent(Agent):
             Custom JSON Encoder to encode tool results with, prior to sending them to the LLM
         include_reasoning_text_within_thinking_tags : bool
             Should reasoning texts be included (within <thinking> tags) in the output of converse and converse_stream? (Default: True)
+        name : str | None, optional
+            Name of the agent when used as a tool
+        description : str | None, optional
+            Description of the agent when used as a tool
+        input_schema : dict[str, Any] | None, optional
+            JSON schema for the input when the agent is used as a tool. If not provided, the agent is assumed to take its input as as single string.
         """
         self._system_prompt = system_prompt
         self._model_id = model_id
@@ -379,6 +402,14 @@ class BedrockConverseAgent(Agent):
         self.include_reasoning_text_within_thinking_tags = (
             include_reasoning_text_within_thinking_tags
         )
+        self.name = name
+        "Name of the agent when used as a tool"
+
+        self.description = description
+        "Description of the agent when used as a tool"
+
+        self.input_schema = input_schema
+        "JSON schema (override) for the input when the agent is used as a tool"
 
     @classmethod
     def _prune_instances_used(cls):
@@ -562,6 +593,10 @@ class BedrockConverseAgent(Agent):
                 tool = tools.get(tool_name)
                 if not tool:
                     raise ValueError(f"Unknown tool: {tool_name}")
+                if isinstance(tool, AgentAsTool):
+                    tool.set_auth_context(self.auth_context)
+                    tool.set_conversation_id(self.conversation_id)
+                    tool.set_trace_context(span=self.tracer.current_trace)
                 tool_response = tool.invoke(**tool_use["input"])
                 trace.add_attribute("ai.tool.output", tool_response)
                 if not isinstance(tool_response, dict):
@@ -1013,8 +1048,6 @@ class BedrockConverseAgent(Agent):
 
                     elif "messageStop" in stream_event:
                         stop_reason = stream_event["messageStop"]["stopReason"]
-                        if texts[-1]:
-                            texts.append("")
                         yield "\n"
                         concatenated += "\n"
 
@@ -1146,3 +1179,67 @@ class BedrockConverseAgent(Agent):
                 content_block["reasoningContent"]["redactedContent"] = redacted_content
 
         return content_block
+
+    def invoke(self, *args, **kwargs) -> Any:
+        if not self.input_schema:
+            user_input = kwargs.pop("user_input")
+        else:
+            params = {}
+            for param_name in self.input_schema["properties"]:
+                if param_name in kwargs:
+                    param_value = kwargs.pop(param_name)
+                    params[param_name] = param_value
+            user_input = f"Your input is:\n\n{json.dumps(params)}"
+        return self.converse(*args, **kwargs, user_input=user_input)
+
+    @property
+    def tool_spec(self) -> "ToolSpecificationTypeDef":
+        if not self.name:
+            raise RuntimeError(
+                "Missing name. When using an agent as tool, the agent must be instantiated with a name"
+            )
+
+        if not self.description:
+            raise RuntimeError(
+                "Missing description. When using an agent as tool, the agent must be instantiated with a description"
+            )
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": {
+                "json": self.input_schema
+                or {
+                    "type": "object",
+                    "properties": {
+                        "user_input": {
+                            "type": "string",
+                            "description": "The input to the agent",
+                        },
+                    },
+                    "required": ["user_input"],
+                }
+            },
+        }
+
+
+@runtime_checkable
+class AgentAsTool(Protocol):
+    def set_trace_context(
+        self, **update: Unpack[TraceContextUpdate]
+    ) -> Callable[[], None]:
+        """
+        Set the trace context of the agent
+        """
+        ...
+
+    def set_conversation_id(self, conversation_id: str) -> None:
+        """
+        Set the conversation id of the agent.
+        """
+        ...
+
+    def set_auth_context(self, auth_context: str | None) -> None:
+        """
+        Set the auth context of the agent.
+        """
+        ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from multi_agent import multi_agent
 from sample_agent_1 import sample_agent_1
 from sample_agent_2 import sample_agent_2
 
@@ -37,6 +38,11 @@ def mock_agent_1(mock_bedrock_converse):
 @pytest.fixture
 def mock_agent_2(mock_bedrock_converse):
     yield sample_agent_2(session=mock_bedrock_converse.session())
+
+
+@pytest.fixture
+def mock_multi_agent():
+    yield multi_agent()
 
 
 @pytest.fixture

--- a/tests/multi_agent.py
+++ b/tests/multi_agent.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from generative_ai_toolkit.agent import BedrockConverseAgent
+from generative_ai_toolkit.test.mock import MockBedrockConverse
+
+
+def multi_agent():
+    supervisor_mock = MockBedrockConverse()
+    weather_agent_mock = MockBedrockConverse()
+    events_agent_mock = MockBedrockConverse()
+
+    def get_weather(city: str):
+        """
+        Gets the weather forecast for the provided city
+
+        Parameters
+        ---
+        city : string
+          The city to get the weather forecast for
+        """
+        return "Sunny"
+
+    weather_agent = BedrockConverseAgent(
+        model_id="dummy",
+        session=weather_agent_mock.session(),
+        system_prompt="You provide the weather forecast for the specified city.",
+        name="transfer_to_weather_agent",
+        description="Get the weather forecast for a city.",
+    )
+    weather_agent.register_tool(get_weather)
+
+    def get_events(city: str):
+        """
+        Gets upcoming events (concerts, festivals, etc) in the provided city
+
+        Parameters
+        ---
+        city : string
+          The city to get the upcoming events for
+        """
+        return [
+            {"name": "Nirvana tribute band concert", "when": "Tomorrow"},
+            {"name": "Food truck festival", "when": "Coming Saturday"},
+            {
+                "name": "Open Museum day -- all museums have free entry",
+                "when": "Coming Sunday",
+            },
+        ]
+
+    events_agent = BedrockConverseAgent(
+        model_id="dummy",
+        session=events_agent_mock.session(),
+        system_prompt="You provide the upcoming events for the specified city.",
+        name="transfer_to_events_agent",
+        description="Get the upcoming events for a city.",
+    )
+    events_agent.register_tool(get_events)
+
+    supervisor = BedrockConverseAgent(
+        model_id="dummy",
+        session=supervisor_mock.session(),
+        system_prompt="You provide users current information on cities that they may want to visit",
+    )
+    supervisor.register_tool(weather_agent)
+    supervisor.register_tool(events_agent)
+
+    return [
+        supervisor,
+        events_agent,
+        weather_agent,
+        supervisor_mock,
+        events_agent_mock,
+        weather_agent_mock,
+    ]

--- a/tests/unit/mcp.json
+++ b/tests/unit/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "WeatherForecasts": {
-      "command": "python3",
+      "command": "python",
       "args": ["mcp_server_get_weather.py"],
       "env": {
         "WEATHER": "Sunny",

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -33,7 +33,7 @@ def test_mcp_client(mock_bedrock_converse):
                 "args": [
                     "mcp_server_get_weather.py",
                 ],
-                "command": "python3",
+                "command": "python",
                 "env": {
                     "WEATHER": "Sunny",
                     "FASTMCP_LOG_LEVEL": "ERROR",

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from generative_ai_toolkit.test import Expect
+
+
+def test_multi_agent(mock_multi_agent):
+    [
+        supervisor,
+        events_agent,
+        weather_agent,
+        supervisor_mock,
+        events_agent_mock,
+        weather_agent_mock,
+    ] = mock_multi_agent
+
+    supervisor_mock.add_output(
+        tool_use_output=[
+            {"name": "transfer_to_weather_agent", "input": {"user_input": "Amsterdam"}},
+            {"name": "transfer_to_events_agent", "input": {"user_input": "Amsterdam"}},
+        ]
+    )
+    weather_agent_mock.add_output(
+        tool_use_output=[
+            {"name": "get_weather", "input": {"city": "Amsterdam"}},
+        ]
+    )
+    weather_agent_mock.add_output(
+        text_output=["The weather in Amsterdam will be Sunny"],
+    )
+    events_agent_mock.add_output(
+        tool_use_output=[
+            {"name": "get_events", "input": {"city": "Amsterdam"}},
+        ]
+    )
+    events_agent_mock.add_output(
+        text_output=["These are the coming events in Amsterdam: bla bla bla"],
+    )
+    supervisor_mock.add_output(
+        text_output=[
+            "The weather in Amsterdam will be Sunny and the coming events are bla bla bla"
+        ]
+    )
+    supervisor.converse("I want to go to Amsterdam, what is up there?")
+
+    Expect(weather_agent.traces).tool_invocations.to_include("get_weather").with_input(
+        {"city": "Amsterdam"}
+    )
+    Expect(weather_agent.traces).user_input.to_equal("Amsterdam")
+    Expect(events_agent.traces).tool_invocations.to_include("get_events").with_input(
+        {"city": "Amsterdam"}
+    )
+    Expect(events_agent.traces).user_input.to_equal("Amsterdam")
+    Expect(supervisor.traces).tool_invocations.to_include("transfer_to_weather_agent")
+    Expect(supervisor.traces).tool_invocations.to_include("transfer_to_events_agent")
+    Expect(supervisor.traces).agent_text_response.to_equal(
+        "The weather in Amsterdam will be Sunny and the coming events are bla bla bla"
+    )
+
+    trace_id = supervisor.traces[0].trace_id
+    for trace in [*supervisor.traces, *weather_agent.traces, *events_agent.traces]:
+        assert trace.trace_id == trace_id
+
+    for supervisor_trace in supervisor.traces:
+        if supervisor_trace.attributes["ai.trace.type"] == "tool-invocation":
+            for subordinate_agent in [events_agent, weather_agent]:
+                if (
+                    supervisor_trace.attributes["ai.tool.name"]
+                    == subordinate_agent.name
+                ):
+                    supervisor_span_id = supervisor_trace.span_id
+                    subordinate_agent_root_trace = subordinate_agent.traces[0]
+                    assert (
+                        supervisor_span_id
+                        == subordinate_agent_root_trace.parent_span.span_id
+                    )

--- a/tests/unit/test_traces_ui.py
+++ b/tests/unit/test_traces_ui.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from generative_ai_toolkit.ui import chat_messages_from_traces
+
+
+def test_chat_messages_from_traces_converse(mock_multi_agent):
+    [
+        supervisor,
+        events_agent,
+        weather_agent,
+        supervisor_mock,
+        events_agent_mock,
+        weather_agent_mock,
+    ] = mock_multi_agent
+
+    def populate_mock():
+        supervisor_mock.add_output(
+            tool_use_output=[
+                {
+                    "name": "transfer_to_weather_agent",
+                    "input": {"user_input": "Amsterdam"},
+                },
+                {
+                    "name": "transfer_to_events_agent",
+                    "input": {"user_input": "Amsterdam"},
+                },
+            ]
+        )
+        weather_agent_mock.add_output(
+            tool_use_output=[
+                {"name": "get_weather", "input": {"city": "Amsterdam"}},
+            ]
+        )
+        weather_agent_mock.add_output(
+            text_output=["The weather in Amsterdam will be Sunny"],
+        )
+        events_agent_mock.add_output(
+            tool_use_output=[
+                {"name": "get_events", "input": {"city": "Amsterdam"}},
+            ]
+        )
+        events_agent_mock.add_output(
+            text_output=["These are the coming events in Amsterdam: bla bla bla"],
+        )
+        supervisor_mock.add_output(
+            text_output=[
+                "The weather in Amsterdam will be Sunny and the coming events are bla bla bla"
+            ]
+        )
+
+    for method in [supervisor.converse, supervisor.converse_stream]:
+        supervisor.reset()
+        populate_mock()
+        list(method("I want to go to Amsterdam, what is up there?"))
+
+        *_, messages = chat_messages_from_traces(
+            supervisor.traces,
+        )
+
+        assert len(messages) == 6
+        text = messages[-1].content
+        assert (
+            type(text) is str
+            and text.strip()
+            == "The weather in Amsterdam will be Sunny and the coming events are bla bla bla"
+        )
+        assert messages[-1].role == "assistant"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Extended the `BedrockConverseAgent` so you can use instances of `BedrockConverseAgent` as tool for other `BedrockConverseAgent` instances.

This allows you to build hierarchical multi-agent systems, where a supervisor agent can use specialized subordinate agents to delegate tasks to.

To use an agent as a tool, the agent must have a `name` and `description`:

(Note: the example below is deliberately contrived to keep the sample code simple; you would not actually need a multi-agent architecture here)

```python
# Create a specialized weather agent:
weather_agent = BedrockConverseAgent(
    model_id="anthropic.claude-3-haiku-20240307-v1:0",
    system_prompt="You provide the weather forecast for the specified city.",
    name="transfer_to_weather_agent",  # will be used as the tool name when registered
    description="Get the weather forecast for a city.",  # will be used as the tool description
)

# Add tools to the specialized agent:
def get_weather(city: str):
    """Gets the weather forecast for the provided city"""
    return "Sunny"

weather_agent.register_tool(get_weather)

# Create a supervisor agent that uses the specialized agent:
supervisor = BedrockConverseAgent(
    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
    system_prompt="You provide users with information about cities they want to visit.",
)

# Register the specialized agent as a tool with the supervisor:
supervisor.register_tool(weather_agent)

# Now, when chatting with the supervisor, it will delegate to the specialized agent:
# (it will be invoked under the hood, as tool)
response = supervisor.converse("What's the weather like in Amsterdam?")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
