### PR TITLE
Update agent.py, increased default for max_successive_tool_invocations

### DIFF
--- a/src/generative_ai_toolkit/agent/agent.py
+++ b/src/generative_ai_toolkit/agent/agent.py
@@ -253,7 +253,7 @@ class BedrockConverseAgent(Agent):
         session: boto3.session.Session | None = None,
         bedrock_client: "BedrockRuntimeClient | None" = None,
         tools: Sequence[Callable] | None = None,
-        max_successive_tool_invocations: int = 10,
+        max_successive_tool_invocations: int = 30,
         executor: Executor | None = None,
         tool_result_json_encoder: type[json.JSONEncoder] | None = None,
         include_reasoning_text_within_thinking_tags=True,
@@ -307,7 +307,7 @@ class BedrockConverseAgent(Agent):
         tools : Sequence[Callable] | None, optional
             Tools available to the agent
         max_successive_tool_invocations : int, optional
-            Maximum number of consecutive tool calls, by default 10
+            Maximum number of consecutive tool calls, by default 30
         executor : Executor | None, optional
             Executor for parallelizing tool invocations. By default, a ThreadPoolExecutor with 8 workers is used.
         tool_result_json_encoder : type[json.JSONEncoder], optional


### PR DESCRIPTION
I'd like to suggest to increase the default value for max_successive_tool_invocations to something a bit more generous.

*Issue #, if available:*

*Description of changes:*

When testing an LLM agent that does many tool calls, I was often running into "Exception: Too many successive tool invocations". As this happened only with certain LLM models, I thought I was hitting a rate limit in my AWS account. Only when I still received these exceptions after the rate limit was increased, I realized that this was an exception raised by the generative_ai_toolkit library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
