### PR TITLE
feat: add MCP server tool verification

### DIFF
--- a/tests/unit/mcp.json
+++ b/tests/unit/mcp.json
@@ -6,7 +6,8 @@
       "env": {
         "WEATHER": "Sunny",
         "FASTMCP_LOG_LEVEL": "ERROR"
-      }
+      },
+      "expectation": "I will use this tool to check the weather"
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Created a hook that allows you test verify MCP server tool descriptions before registering them in the agent.

While at it made the MCP tool registration more efficient by parallelizing it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
