### PR TITLE
feat: show path to JSON file with problem

### DIFF
--- a/src/generative_ai_toolkit/mcp/client.py
+++ b/src/generative_ai_toolkit/mcp/client.py
@@ -209,6 +209,8 @@ class McpClient:
                 if not paths:
                     # Using default locations
                     continue
+            except json.decoder.JSONDecodeError as err:
+                raise RuntimeError(f"Failed to parse {path}: {err}") from err
             else:
                 break
         else:

--- a/tests/unit/invalid.json
+++ b/tests/unit/invalid.json
@@ -1,0 +1,5 @@
+{
+  "mcpServers": {
+      NOT VALID JSON
+  }
+}

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -14,6 +14,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from generative_ai_toolkit.agent import Agent, BedrockConverseAgent
 from generative_ai_toolkit.mcp.client import McpClient
 from generative_ai_toolkit.test import Expect
@@ -52,3 +54,11 @@ def test_mcp_client(mock_bedrock_converse):
 
     Expect(agent.traces).tool_invocations.to_include("current_weather")
     Expect(agent.traces).agent_text_response.to_equal("Sunny")
+
+
+def test_invalid_json(mock_bedrock_converse):
+    agent = BedrockConverseAgent(
+        model_id="dummy", session=mock_bedrock_converse.session()
+    )
+    with pytest.raises(RuntimeError, match="invalid.json"):
+        McpClient(agent, client_config_path=str(HERE / "invalid.json"))


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* If your MCP config file is not proper JSON, the error will tell you which path was tried


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
