### PR TITLE
Mark Python 3.13 as the minimum Python version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.13"
 
       - name: Set AWS region (to prevent boto3 errors)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "testing",
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 license = { text = "Apache-2.0" }
 dependencies = ["boto3>=1.37,<2.0"]
 authors = [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Mark Python 3.13 as the minimum Python version.

Since #40 where we were using `Shutdown` from `queue` this actually became the case, and we didn't notice it ...
Pinned the Python version in the GitHub workflow YAML to 3.13 explicitly now so this does not happen again as easily.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
