### PR TITLE
feat: expose context to tools

### DIFF
--- a/examples/tracing101.ipynb
+++ b/examples/tracing101.ipynb
@@ -19,8 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
-    "\n",
     "from generative_ai_toolkit.tracer import (\n",
     "    HumanReadableTracer,\n",
     "    InMemoryTracer,\n",
@@ -31,7 +29,19 @@
     "    Tracer,\n",
     ")\n",
     "from generative_ai_toolkit.tracer.dynamodb import DynamoDbTracer\n",
-    "from generative_ai_toolkit.tracer.otlp import OtlpTracer\n",
+    "from generative_ai_toolkit.tracer.otlp import OtlpTracer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4ea4e83e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Other imports\n",
+    "import time\n",
+    "\n",
     "from generative_ai_toolkit.utils.ulid import Ulid"
    ]
   },
@@ -47,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "8c97c8df",
    "metadata": {},
    "outputs": [
@@ -55,9 +65,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='67a32a7c5da62a13a9697bce7ed3eb11', span_id='869f6cfef9c84be1', parent_span_id=None, started_at=datetime.datetime(2025, 4, 17, 18, 40, 4, 888534, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 5, 96727, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar', 'inherited.foo': 'bar'}, span_status='UNSET', resource_attributes={'service.name': 'MyAgent'}, scope=generative-ai-toolkit@current)\n",
+      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='adcd3c555260da3929033531e821e89c', span_id='89c916d2d63aa46a', parent_span_id=None, started_at=datetime.datetime(2025, 7, 4, 11, 12, 48, 665922, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 48, 873655, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar', 'inherited.foo': 'bar'}, span_status='UNSET', resource_attributes={'service.name': 'MyAgent'}, scope=generative-ai-toolkit@current)\n",
       "\n",
-      "Trace(span_name='child', span_kind='INTERNAL', trace_id='67a32a7c5da62a13a9697bce7ed3eb11', span_id='e20697ba3a8345c5', parent_span_id='869f6cfef9c84be1', started_at=datetime.datetime(2025, 4, 17, 18, 40, 4, 992046, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 5, 96685, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'inherited.foo': 'bar'}, span_status='UNSET', resource_attributes={'service.name': 'MyAgent'}, scope=generative-ai-toolkit@current)\n",
+      "Trace(span_name='child', span_kind='INTERNAL', trace_id='adcd3c555260da3929033531e821e89c', span_id='608c44b632ecab87', parent_span_id='89c916d2d63aa46a', started_at=datetime.datetime(2025, 7, 4, 11, 12, 48, 768497, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 48, 873590, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'inherited.foo': 'bar'}, span_status='UNSET', resource_attributes={'service.name': 'MyAgent'}, scope=generative-ai-toolkit@current)\n",
       "\n"
      ]
     }
@@ -101,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "614dbe8f",
    "metadata": {},
    "outputs": [
@@ -109,12 +119,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[94m[b5d34de4dbe2b0fa57482f7f45107e0b/root/2356ae1dd5c2a658]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-04-17T18:40:05.103Z - parent (\u001b[93mai.conversation.id='01JS2GT2ZF7NVKR46VQC9BKJT6' ai.auth.context='user123'\u001b[0m)\n",
+      "\u001b[94m[94e99f04b60cea27d7b0f744b4a17d3e/root/6c894f8009912f45]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-07-04T11:12:48.882Z - parent\n",
+      "  \u001b[93mai.conversation.id=01JZAJ75QJP9K1BFZM8SJRBB1B ai.auth.context=user123\u001b[0m\n",
       "\n",
       "\n",
-      "\u001b[94m[b5d34de4dbe2b0fa57482f7f45107e0b/2356ae1dd5c2a658/ce47551f27b4cf10]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:05.208Z - child (\u001b[93mai.trace.type='tool-invocation' ai.conversation.id='01JS2GT2ZF7NVKR46VQC9BKJT6' ai.auth.context='user123'\u001b[0m)\n",
-      "\u001b[90m       Input: Hello, world!\u001b[0m\n",
-      "\u001b[90m      Output: World, hello!\u001b[0m\n",
+      "\u001b[94m[94e99f04b60cea27d7b0f744b4a17d3e/6c894f8009912f45/681c5348bf73ae80]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:48.987Z - child\n",
+      "  \u001b[93mai.trace.type=tool-invocation ai.conversation.id=01JZAJ75QJP9K1BFZM8SJRBB1B ai.auth.context=user123\u001b[0m\n",
+      "\u001b[90m         Input: Hello, world!\u001b[0m\n",
+      "\u001b[90m        Output: World, hello!\u001b[0m\n",
       "\n",
       "\n"
      ]
@@ -125,7 +137,7 @@
     "\n",
     "with in_memory_tracer.trace(\"parent\", span_kind=\"SERVER\") as parent_span:\n",
     "    parent_span.add_attribute(\"ai.conversation.id\", conversation_id, inheritable=True)\n",
-    "    parent_span.add_attribute(\"ai.auth.context\", \"user123\", inheritable=True)\n",
+    "    parent_span.add_attribute(\"ai.auth.context\", {\"principal_id\":\"user123\"}, inheritable=True)\n",
     "    time.sleep(0.1)\n",
     "\n",
     "    with in_memory_tracer.trace(\"child\") as child_span:\n",
@@ -158,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "a35fcdaf",
    "metadata": {},
    "outputs": [
@@ -166,11 +178,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[94m[11effc51d176237146ed5bdbc0c56114/01432762046b3ead/cd13e44739b4e39e]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:05.430Z - child (\u001b[93mai.trace.type='tool-invocation' ai.conversation.id='01JS2GT2ZF7NVKR46VQC9BKJT6' ai.auth.context='user123'\u001b[0m)\n",
-      "\u001b[90m       Input: Hello, world!\u001b[0m\n",
-      "\u001b[90m      Output: World, hello!\u001b[0m\n",
+      "\u001b[94m[3b5a67be32c72869ce695281bdad26dd/fad7b98c935591ee/ba0711bbf950ec36]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:49.212Z - child\n",
+      "  \u001b[93mai.trace.type=tool-invocation ai.conversation.id=01JZAJ75QJP9K1BFZM8SJRBB1B ai.auth.context=user123\u001b[0m\n",
+      "\u001b[90m         Input: Hello, world!\u001b[0m\n",
+      "\u001b[90m        Output: World, hello!\u001b[0m\n",
       "\n",
-      "\u001b[94m[11effc51d176237146ed5bdbc0c56114/root/01432762046b3ead]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-04-17T18:40:05.325Z - parent (\u001b[93mai.conversation.id='01JS2GT2ZF7NVKR46VQC9BKJT6' ai.auth.context='user123'\u001b[0m)\n",
+      "\u001b[94m[3b5a67be32c72869ce695281bdad26dd/root/fad7b98c935591ee]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-07-04T11:12:49.108Z - parent\n",
+      "  \u001b[93mai.conversation.id=01JZAJ75QJP9K1BFZM8SJRBB1B ai.auth.context=user123\u001b[0m\n",
       "\n"
      ]
     }
@@ -184,7 +198,7 @@
     "\n",
     "with human_readable_tracer.trace(\"parent\", span_kind=\"SERVER\") as parent_span:\n",
     "    parent_span.add_attribute(\"ai.conversation.id\", conversation_id, inheritable=True)\n",
-    "    parent_span.add_attribute(\"ai.auth.context\", \"user123\", inheritable=True)\n",
+    "    parent_span.add_attribute(\"ai.auth.context\", {\"principal_id\":\"user123\"}, inheritable=True)\n",
     "    time.sleep(0.1)\n",
     "\n",
     "    with human_readable_tracer.trace(\"child\") as child_span:\n",
@@ -206,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "1a58232d",
    "metadata": {},
    "outputs": [
@@ -214,8 +228,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"logger\":\"TraceLogger\",\"level\":\"INFO\",\"message\":\"Trace\",\"trace\":{\"span_name\":\"child\",\"span_kind\":\"INTERNAL\",\"trace_id\":\"c2991f68279180b89cfba134e27429da\",\"span_id\":\"bc7fc0d01ca8797b\",\"parent_span_id\":\"c180c46a3b6b1ace\",\"started_at\":\"2025-04-17 18:40:05.650153+00:00\",\"ended_at\":\"2025-04-17 18:40:05.755206+00:00\",\"attributes\":{\"ai.trace.type\":\"tool-invocation\",\"ai.tool.input\":\"Hello, world!\",\"ai.tool.output\":\"World, hello!\",\"ai.conversation.id\":\"01JS2GT2ZF7NVKR46VQC9BKJT6\",\"ai.auth.context\":\"user123\"},\"span_status\":\"UNSET\",\"resource_attributes\":{\"service.name\":\"MyAgent\"},\"scope\":{\"name\":\"generative-ai-toolkit\",\"version\":\"current\"}}}\n",
-      "{\"logger\":\"TraceLogger\",\"level\":\"INFO\",\"message\":\"Trace\",\"trace\":{\"span_name\":\"parent\",\"span_kind\":\"SERVER\",\"trace_id\":\"c2991f68279180b89cfba134e27429da\",\"span_id\":\"c180c46a3b6b1ace\",\"parent_span_id\":null,\"started_at\":\"2025-04-17 18:40:05.549289+00:00\",\"ended_at\":\"2025-04-17 18:40:05.755649+00:00\",\"attributes\":{\"ai.conversation.id\":\"01JS2GT2ZF7NVKR46VQC9BKJT6\",\"ai.auth.context\":\"user123\"},\"span_status\":\"UNSET\",\"resource_attributes\":{\"service.name\":\"MyAgent\"},\"scope\":{\"name\":\"generative-ai-toolkit\",\"version\":\"current\"}}}\n"
+      "{\"logger\":\"TraceLogger\",\"level\":\"INFO\",\"message\":\"Trace\",\"trace\":{\"span_name\":\"child\",\"span_kind\":\"INTERNAL\",\"trace_id\":\"f2bb49eae88af55475fd98b3b7862ab3\",\"span_id\":\"fef4a910c00969f3\",\"parent_span_id\":\"ee2bf749c66fd317\",\"started_at\":\"2025-07-04 11:12:49.431790+00:00\",\"ended_at\":\"2025-07-04 11:12:49.535886+00:00\",\"duration_ms\":104,\"attributes\":{\"ai.trace.type\":\"tool-invocation\",\"ai.tool.input\":\"Hello, world!\",\"ai.tool.output\":\"World, hello!\",\"ai.conversation.id\":\"01JZAJ75QJP9K1BFZM8SJRBB1B\",\"ai.auth.context\":{\"principal_id\":\"user123\"}},\"span_status\":\"UNSET\",\"resource_attributes\":{\"service.name\":\"MyAgent\"},\"scope\":{\"name\":\"generative-ai-toolkit\",\"version\":\"current\"}}}\n",
+      "{\"logger\":\"TraceLogger\",\"level\":\"INFO\",\"message\":\"Trace\",\"trace\":{\"span_name\":\"parent\",\"span_kind\":\"SERVER\",\"trace_id\":\"f2bb49eae88af55475fd98b3b7862ab3\",\"span_id\":\"ee2bf749c66fd317\",\"parent_span_id\":null,\"started_at\":\"2025-07-04 11:12:49.330367+00:00\",\"ended_at\":\"2025-07-04 11:12:49.536632+00:00\",\"duration_ms\":206,\"attributes\":{\"ai.conversation.id\":\"01JZAJ75QJP9K1BFZM8SJRBB1B\",\"ai.auth.context\":{\"principal_id\":\"user123\"}},\"span_status\":\"UNSET\",\"resource_attributes\":{\"service.name\":\"MyAgent\"},\"scope\":{\"name\":\"generative-ai-toolkit\",\"version\":\"current\"}}}\n"
      ]
     }
    ],
@@ -226,7 +240,7 @@
     "\n",
     "with structured_logs_tracer.trace(\"parent\", span_kind=\"SERVER\") as parent_span:\n",
     "    parent_span.add_attribute(\"ai.conversation.id\", conversation_id, inheritable=True)\n",
-    "    parent_span.add_attribute(\"ai.auth.context\", \"user123\", inheritable=True)\n",
+    "    parent_span.add_attribute(\"ai.auth.context\", {\"principal_id\":\"user123\"}, inheritable=True)\n",
     "    time.sleep(0.1)\n",
     "\n",
     "    with structured_logs_tracer.trace(\"child\") as child_span:\n",
@@ -254,10 +268,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "62bc3e2b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "An error occurred (ResourceInUseException) when calling the CreateTable operation: Table already exists: MyTracesTable\n"
+     ]
+    }
+   ],
    "source": [
     "!aws dynamodb create-table \\\n",
     "  --table-name MyTracesTable \\\n",
@@ -282,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "a4ad9e7d",
    "metadata": {},
    "outputs": [
@@ -290,12 +313,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[94m[4b99255b0cfa0f5240daadb8f5c12989/root/09fb672e5eb74018]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-04-17T18:40:09.253Z - parent (\u001b[93mai.conversation.id='01JS2GT5QH9A71AR8WP3Y87DPD' ai.auth.context='user123'\u001b[0m)\n",
+      "\u001b[94m[146d4a9c8cdd77aee8dcfe4d3db41513/root/19871a56135db8ac]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-07-04T11:12:54.586Z - parent\n",
+      "  \u001b[93mai.conversation.id=01JZAJ79NR857YAE89GF02WE2S ai.auth.context=user123\u001b[0m\n",
       "\n",
       "\n",
-      "\u001b[94m[4b99255b0cfa0f5240daadb8f5c12989/09fb672e5eb74018/d9a755f3fb6adcd8]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:09.357Z - child (\u001b[93mai.trace.type='tool-invocation' ai.conversation.id='01JS2GT5QH9A71AR8WP3Y87DPD' ai.auth.context='user123'\u001b[0m)\n",
-      "\u001b[90m       Input: Hello, world!\u001b[0m\n",
-      "\u001b[90m      Output: World, hello!\u001b[0m\n",
+      "\u001b[94m[146d4a9c8cdd77aee8dcfe4d3db41513/19871a56135db8ac/dc378eb1b7c257b8]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:54.689Z - child\n",
+      "  \u001b[93mai.trace.type=tool-invocation ai.conversation.id=01JZAJ79NR857YAE89GF02WE2S ai.auth.context=user123\u001b[0m\n",
+      "\u001b[90m         Input: Hello, world!\u001b[0m\n",
+      "\u001b[90m        Output: World, hello!\u001b[0m\n",
       "\n",
       "\n"
      ]
@@ -303,7 +328,7 @@
    ],
    "source": [
     "conversation_id = Ulid().ulid\n",
-    "auth_context = \"user123\"\n",
+    "auth_context = {\"principal_id\":\"user123\"}\n",
     "\n",
     "ddb_tracer = DynamoDbTracer(\n",
     "    table_name=\"MyTracesTable\",\n",
@@ -349,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "bab55432",
    "metadata": {},
    "outputs": [],
@@ -396,10 +421,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "9c9ce5e4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\n",
+      "2ebcfa9cba8fc84de6e28e07faa92232bd82f667277eb3b2f907554902d7b248\n",
+      "2025/07/04 11:12:55 ADOT Collector version: v0.43.2\n",
+      "2025/07/04 11:12:56 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory\n",
+      "2025/07/04 11:12:56 attn: users of the `datadog`, `logzio`, `sapm`, `signalfx` exporter components. please refer to https://github.com/aws-observability/aws-otel-collector/issues/2734 in regards to an upcoming ADOT Collector breaking change\n",
+      "2025-07-04T11:12:56.055Z\tinfo\tservice@v0.117.0/service.go:164\tSetting up own telemetry...\n",
+      "2025-07-04T11:12:56.058Z\tinfo\ttelemetry/metrics.go:70\tServing metrics\t{\"address\": \"localhost:8888\", \"metrics level\": \"Normal\"}\n",
+      "2025-07-04T11:12:56.092Z\tinfo\tservice@v0.117.0/service.go:230\tStarting aws-otel-collector...\t{\"Version\": \"v0.43.2\", \"NumCPU\": 2}\n",
+      "2025-07-04T11:12:56.092Z\tinfo\textensions/extensions.go:39\tStarting extensions...\n",
+      "2025-07-04T11:12:56.094Z\tinfo\totlpreceiver@v0.117.0/otlp.go:169\tStarting HTTP server\t{\"kind\": \"receiver\", \"name\": \"otlp\", \"data_type\": \"traces\", \"endpoint\": \"0.0.0.0:4318\"}\n",
+      "2025-07-04T11:12:56.095Z\tinfo\tservice@v0.117.0/service.go:253\tEverything is ready. Begin running and processing data.\n"
+     ]
+    }
+   ],
    "source": [
     "!docker run --rm -d --name adot-collector \\\n",
     "  -p 4318:4318 \\\n",
@@ -424,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "6e333428",
    "metadata": {},
    "outputs": [],
@@ -435,7 +478,7 @@
     "\n",
     "with otlp_tracer.trace(\"parent\", span_kind=\"SERVER\") as parent_span:\n",
     "    parent_span.add_attribute(\"ai.conversation.id\", \"123456\", inheritable=True)\n",
-    "    parent_span.add_attribute(\"ai.auth.context\", \"user123\", inheritable=True)\n",
+    "    parent_span.add_attribute(\"ai.auth.context\", {\"principal_id\":\"user123\"}, inheritable=True)\n",
     "    time.sleep(0.1)\n",
     "\n",
     "    with otlp_tracer.trace(\"child\") as child_span:\n",
@@ -475,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "b4630086",
    "metadata": {},
    "outputs": [],
@@ -503,17 +546,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "ea950cba",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<generative_ai_toolkit.tracer.tracer.TeeTracer at 0x11638cb60>"
+       "<generative_ai_toolkit.tracer.tracer.TeeTracer at 0x10c545a90>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -538,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "f206ac46",
    "metadata": {},
    "outputs": [
@@ -548,20 +591,24 @@
      "text": [
       "==== live traces: ====\n",
       "\n",
-      "\u001b[94m[3cf33cc4a29d949f302393becdb8803d/0ee353668bbee0a9/eae94b1e302ad96d]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:13.271Z - child (\u001b[93mai.trace.type='tool-invocation' ai.conversation.id='01JS2GTAVHHW27ZE1VFXZT8ZJA' ai.auth.context='user456'\u001b[0m)\n",
-      "\u001b[90m       Input: Hello, world!\u001b[0m\n",
-      "\u001b[90m      Output: World, hello!\u001b[0m\n",
+      "\u001b[94m[ef04cce04e9d38285a49e58b14a0a1af/4dd28f3ac0a0794a/a254fde0f24d13f8]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:58.821Z - child\n",
+      "  \u001b[93mai.trace.type=tool-invocation ai.conversation.id=01JZAJ7FB0TE8Y0ZX00N1SDQVV ai.auth.context=user456\u001b[0m\n",
+      "\u001b[90m         Input: Hello, world!\u001b[0m\n",
+      "\u001b[90m        Output: World, hello!\u001b[0m\n",
       "\n",
-      "\u001b[94m[3cf33cc4a29d949f302393becdb8803d/root/0ee353668bbee0a9]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-04-17T18:40:13.170Z - parent (\u001b[93mai.conversation.id='01JS2GTAVHHW27ZE1VFXZT8ZJA' ai.auth.context='user456'\u001b[0m)\n",
+      "\u001b[94m[ef04cce04e9d38285a49e58b14a0a1af/root/4dd28f3ac0a0794a]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-07-04T11:12:58.721Z - parent\n",
+      "  \u001b[93mai.conversation.id=01JZAJ7FB0TE8Y0ZX00N1SDQVV ai.auth.context=user456\u001b[0m\n",
       "\n",
       "==== traces from DynamoDB: ====\n",
       "\n",
-      "\u001b[94m[3cf33cc4a29d949f302393becdb8803d/root/0ee353668bbee0a9]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-04-17T18:40:13.170Z - parent (\u001b[93mai.conversation.id='01JS2GTAVHHW27ZE1VFXZT8ZJA' ai.auth.context='user456'\u001b[0m)\n",
+      "\u001b[94m[ef04cce04e9d38285a49e58b14a0a1af/root/4dd28f3ac0a0794a]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[92mSERVER\u001b[0m 2025-07-04T11:12:58.721Z - parent\n",
+      "  \u001b[93mai.conversation.id=01JZAJ7FB0TE8Y0ZX00N1SDQVV ai.auth.context=user456\u001b[0m\n",
       "\n",
       "\n",
-      "\u001b[94m[3cf33cc4a29d949f302393becdb8803d/0ee353668bbee0a9/eae94b1e302ad96d]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:13.271Z - child (\u001b[93mai.trace.type='tool-invocation' ai.conversation.id='01JS2GTAVHHW27ZE1VFXZT8ZJA' ai.auth.context='user456'\u001b[0m)\n",
-      "\u001b[90m       Input: Hello, world!\u001b[0m\n",
-      "\u001b[90m      Output: World, hello!\u001b[0m\n",
+      "\u001b[94m[ef04cce04e9d38285a49e58b14a0a1af/4dd28f3ac0a0794a/a254fde0f24d13f8]\u001b[0m \u001b[96mMyAgent\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:58.821Z - child\n",
+      "  \u001b[93mai.trace.type=tool-invocation ai.conversation.id=01JZAJ7FB0TE8Y0ZX00N1SDQVV ai.auth.context=user456\u001b[0m\n",
+      "\u001b[90m         Input: Hello, world!\u001b[0m\n",
+      "\u001b[90m        Output: World, hello!\u001b[0m\n",
       "\n",
       "\n"
      ]
@@ -569,7 +616,7 @@
    ],
    "source": [
     "conversation_id = Ulid().ulid\n",
-    "auth_context = \"user456\"\n",
+    "auth_context = {\"principal_id\":\"user456\"}\n",
     "\n",
     "tee_tracer.set_context(resource_attributes={\"service.name\": \"MyAgent\"})\n",
     "\n",
@@ -610,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "a3c4c769",
    "metadata": {},
    "outputs": [],
@@ -641,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "b74a99c4",
    "metadata": {},
    "outputs": [
@@ -649,8 +696,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='fc1fa730e4510c00a66b441dc33b6cf7', span_id='d939aa9ac6a37c94', parent_span_id=None, started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 527126, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 736427, tzinfo=datetime.timezone.utc), attributes={}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
-      "Trace(span_name='child', span_kind='INTERNAL', trace_id='fc1fa730e4510c00a66b441dc33b6cf7', span_id='d820e4e53917679e', parent_span_id='d939aa9ac6a37c94', started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 527359, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 632211, tzinfo=datetime.timezone.utc), attributes={}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
+      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='e0f2948f7705263e049e50b3eece34da', span_id='51a2cf0814efe564', parent_span_id=None, started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 83700, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 291396, tzinfo=datetime.timezone.utc), attributes={}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
+      "Trace(span_name='child', span_kind='INTERNAL', trace_id='e0f2948f7705263e049e50b3eece34da', span_id='fd9dac4ada737f76', parent_span_id='51a2cf0814efe564', started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 83827, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 187722, tzinfo=datetime.timezone.utc), attributes={}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
      ]
     }
    ],
@@ -671,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "e105f5ca",
    "metadata": {},
    "outputs": [
@@ -679,8 +726,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='e254f209330877090c65586b4b1b85c2', span_id='c86b85d9e8f5a177', parent_span_id=None, started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 743162, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 949445, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
-      "Trace(span_name='child', span_kind='INTERNAL', trace_id='e254f209330877090c65586b4b1b85c2', span_id='d24a697870d723ac', parent_span_id='c86b85d9e8f5a177', started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 743212, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 848286, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
+      "Trace(span_name='parent', span_kind='INTERNAL', trace_id='d607e0eae6e39063739487f1036dc80a', span_id='dbfb6da2dcd90090', parent_span_id=None, started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 298048, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 507483, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
+      "Trace(span_name='child', span_kind='INTERNAL', trace_id='d607e0eae6e39063739487f1036dc80a', span_id='418e067946334542', parent_span_id='dbfb6da2dcd90090', started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 298133, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 402403, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
      ]
     }
    ],
@@ -717,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "28a248bb",
    "metadata": {},
    "outputs": [
@@ -725,8 +772,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace(span_name='parent_method', span_kind='INTERNAL', trace_id='3b327625f340e89af7f0085edcdf67be', span_id='8fcfb497d3a9efdc', parent_span_id=None, started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 964760, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 14, 175250, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
-      "Trace(span_name='child_method', span_kind='INTERNAL', trace_id='3b327625f340e89af7f0085edcdf67be', span_id='5b33285f4668035b', parent_span_id='8fcfb497d3a9efdc', started_at=datetime.datetime(2025, 4, 17, 18, 40, 13, 965111, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 4, 17, 18, 40, 14, 70238, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
+      "Trace(span_name='parent_method', span_kind='INTERNAL', trace_id='b07bf6adaf0ada642cb2cf6f7a67832a', span_id='1ebb45db1c22a743', parent_span_id=None, started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 522134, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 727517, tzinfo=datetime.timezone.utc), attributes={'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n",
+      "Trace(span_name='child_method', span_kind='INTERNAL', trace_id='b07bf6adaf0ada642cb2cf6f7a67832a', span_id='bc1460775eafbe98', parent_span_id='1ebb45db1c22a743', started_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 523157, tzinfo=datetime.timezone.utc), ended_at=datetime.datetime(2025, 7, 4, 11, 12, 59, 623815, tzinfo=datetime.timezone.utc), attributes={'bar': 'foo', 'foo': 'bar'}, span_status='UNSET', resource_attributes={}, scope=generative-ai-toolkit@current)\n"
      ]
     }
    ],
@@ -775,7 +822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "c6e5ec90",
    "metadata": {},
    "outputs": [
@@ -783,7 +830,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[94m[174615cba5a35e8431b5cfa12bea3423/root/cdde07e75b9a4c00]\u001b[0m \u001b[96m<missing service.name>\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-04-17T18:40:14.192Z - span\n",
+      "\u001b[94m[224706b26a7661d201b69c4ab5426750/root/07744e71cd8fef0a]\u001b[0m \u001b[96m<missing service.name>\u001b[0m \u001b[94mINTERNAL\u001b[0m 2025-07-04T11:12:59.742Z - span\n",
+      "\n",
       "\n"
      ]
     }
@@ -818,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 22,
    "id": "snapshot-example",
    "metadata": {},
    "outputs": [
@@ -903,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 23,
    "id": "snapshot-custom-tracer",
    "metadata": {},
    "outputs": [
@@ -960,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 24,
    "id": "tee-tracer-snapshot-example",
    "metadata": {},
    "outputs": [

--- a/src/generative_ai_toolkit/agent/tool.py
+++ b/src/generative_ai_toolkit/agent/tool.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import inspect
-import json
 import re
 import textwrap
 from collections.abc import Callable
-from datetime import date, datetime, time
 from types import UnionType
 from typing import (
     TYPE_CHECKING,
@@ -49,14 +47,6 @@ class Tool(Protocol):
         """
         ...
 
-
-class ToolResultJsonEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, date | datetime | time):
-            return o.isoformat()
-        elif hasattr(o, "__json__") and callable(o.__json__):
-            return o.__json__()
-        return super().default(o)
 
 
 class BedrockConverseTool(Tool):

--- a/src/generative_ai_toolkit/context/__init__.py
+++ b/src/generative_ai_toolkit/context/__init__.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is in this separate file so it can be imported by both agents and tools
+# without running into circular imports
+
+
+import contextvars
+from typing import Any, NotRequired, TypedDict
+
+from generative_ai_toolkit.tracer import Tracer
+
+
+class AuthContext(TypedDict):
+    principal_id: str | None
+    """
+    The ID of the principal (e.g. the user) that the agent is acting on behalf of
+    """
+
+    # Once https://peps.python.org/pep-0728 lands (Python 3.15?) we can deprecate this property,
+    # as the TypedDict would then allow extra keys itself.
+    extra: NotRequired[Any]
+    """
+    Additional information to add to the AuthContext
+    """
+
+
+class AgentContext:
+
+    _current = contextvars.ContextVar["AgentContext"]("agent_context")
+
+    conversation_id: str
+    tracer: Tracer
+    auth_context: AuthContext
+
+    def __init__(
+        self,
+        *,
+        conversation_id: str,
+        tracer: Tracer,
+        auth_context: AuthContext,
+    ) -> None:
+        self.conversation_id = conversation_id
+        self.tracer = tracer
+        self.auth_context = auth_context
+
+    @classmethod
+    def current(cls):
+        return cls._current.get()
+
+    def copy_context(self):
+        ctx = contextvars.copy_context()
+        ctx.run(lambda: self._current.set(self))
+        return ctx

--- a/src/generative_ai_toolkit/tracer/otlp.py
+++ b/src/generative_ai_toolkit/tracer/otlp.py
@@ -45,12 +45,13 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
     Status as OtlpStatus,
 )
 
+from generative_ai_toolkit.tracer.trace import Trace
 from generative_ai_toolkit.tracer.tracer import (
     BaseTracer,
-    Trace,
     TraceContextProvider,
     TraceScope,
 )
+from generative_ai_toolkit.utils.json import DefaultJsonEncoder
 
 
 @dataclass
@@ -148,7 +149,7 @@ class OtlpBatch:
         elif value is None:
             return OtlpAnyValue()
         else:
-            return OtlpAnyValue(string_value=json.dumps(value, default=str))
+            return OtlpAnyValue(string_value=json.dumps(value, cls=DefaultJsonEncoder))
 
     SPAN_KIND_PROTOBUF_MAPPING = {
         "SERVER": OtlpSpan.SpanKind.SPAN_KIND_SERVER,

--- a/src/generative_ai_toolkit/utils/dynamodb.py
+++ b/src/generative_ai_toolkit/utils/dynamodb.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import json
-from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
+from generative_ai_toolkit.utils.json import DefaultJsonEncoder
 
-class DynamoDbMapper(json.JSONEncoder):
+
+class DynamoDbMapper(DefaultJsonEncoder):
     """
     Helper class to convert Decimal to float, which boto3 dynamodb doesn't do out of the box :(
     """
@@ -28,9 +29,7 @@ class DynamoDbMapper(json.JSONEncoder):
             if o.as_integer_ratio()[1] == 1:
                 return int(o)
             return float(o)
-        if isinstance(o, datetime):
-            return o.isoformat()
-        return str(o)
+        return super().default(o)
 
     @classmethod
     def to_dynamo(cls, data: Any) -> Any:

--- a/src/generative_ai_toolkit/utils/json.py
+++ b/src/generative_ai_toolkit/utils/json.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from datetime import date, datetime, time
+from types import SimpleNamespace
+
+
+class DefaultJsonEncoder(json.JSONEncoder):
+    """
+    A JSON encoder that is a bit more smart, and lenient, than Python's native JSON encoder
+    """
+
+    def default(self, o):
+        if isinstance(o, date | datetime | time):
+            return o.isoformat()
+        if isinstance(o, SimpleNamespace):
+            return o.__dict__
+        elif hasattr(o, "__json__") and callable(o.__json__):
+            return o.__json__()
+        return str(o)

--- a/src/generative_ai_toolkit/utils/logging.py
+++ b/src/generative_ai_toolkit/utils/logging.py
@@ -31,6 +31,7 @@ from collections.abc import Mapping
 from typing import Any, TextIO
 
 from generative_ai_toolkit.utils.cloudwatch import MetricData
+from generative_ai_toolkit.utils.json import DefaultJsonEncoder
 
 in_aws_lambda = os.environ.get("AWS_EXECUTION_ENV", "").startswith("AWS_Lambda_")
 
@@ -73,7 +74,7 @@ class SimpleLogger:
         # Replace line endings so multi-line log messages are still displayed as one record in CloudWatch Logs
         # Flush to stdout immediately (no need to set PYTHONUNBUFFERED)
         print(
-            json.dumps(fields, separators=(",", ":"), default=str).replace(
+            json.dumps(fields, separators=(",", ":"), cls=DefaultJsonEncoder).replace(
                 "\n",
                 "\r" if in_aws_lambda else "\n",  # no-op if not not in AWS Lambda
             ),

--- a/tests/unit/test_agent_context.py
+++ b/tests/unit/test_agent_context.py
@@ -1,0 +1,159 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from generative_ai_toolkit.agent import BedrockConverseAgent
+from generative_ai_toolkit.context import AgentContext, AuthContext
+from generative_ai_toolkit.tracer.trace import Trace
+
+
+def test_tools_can_access_agent_context(mock_bedrock_converse):
+
+    agent = BedrockConverseAgent(
+        model_id="dummy", session=mock_bedrock_converse.session()
+    )
+    test_span_name = "test_tools_can_access_agent_context"
+    test_auth_context: AuthContext = {
+        "principal_id": "test-principal-id",
+        "extra": {"some_other_attribute": "some-other-attribute"},
+    }
+    test_conversation_id = "test-conversation-id"
+    current_trace_during_tool_invocation: Trace | None = None
+
+    def dummy_tool() -> str:
+        """
+        Returns a static string
+        """
+        context = AgentContext.current()
+
+        nonlocal current_trace_during_tool_invocation
+        current_trace_during_tool_invocation = context.tracer.current_trace
+        current_trace_during_tool_invocation.add_attribute("foo", "bar")
+
+        with context.tracer.trace(test_span_name) as trace:
+            trace.add_attribute("test.auth.context", context.auth_context)
+            trace.add_attribute(
+                "test.auth.principal.id", context.auth_context["principal_id"]
+            )
+            trace.add_attribute(
+                "test.auth.some_other_attribute",
+                context.auth_context.get("extra", {})["some_other_attribute"],
+            )
+            trace.add_attribute("test.conversation.id", context.conversation_id)
+
+        return "static string"
+
+    agent.register_tool(dummy_tool)
+
+    mock_bedrock_converse.add_output(
+        tool_use_output={"name": "dummy_tool", "input": {}}
+    )
+    mock_bedrock_converse.add_output("Agent response")
+
+    agent.set_auth_context(**test_auth_context)
+    agent.set_conversation_id(test_conversation_id)
+    agent.converse("Test message")
+
+    tool_invocation_trace = next(
+        trace
+        for trace in agent.traces
+        if trace.attributes.get("ai.trace.type") == "tool-invocation"
+    )
+
+    assert tool_invocation_trace == current_trace_during_tool_invocation
+
+    assert "foo" in tool_invocation_trace.attributes
+    assert tool_invocation_trace.attributes["foo"] == "bar"
+
+    for trace in agent.traces:
+        if trace.span_name == test_span_name:
+            assert trace.parent_span == tool_invocation_trace
+            assert trace.attributes["test.auth.context"] == test_auth_context
+            assert (
+                trace.attributes["test.auth.principal.id"]
+                == test_auth_context["principal_id"]
+            )
+            assert (
+                trace.attributes["test.auth.some_other_attribute"]
+                == test_auth_context.get("extra", {})["some_other_attribute"]
+            )
+            assert trace.attributes["test.conversation.id"] == test_conversation_id
+            break
+    else:
+        raise Exception("Did not find test span in traces!")
+
+
+def test_tools_can_access_agent_context_multi_tool(mock_bedrock_converse):
+    """
+    test that the AgentContext mechanism also works when multiple tools are used
+    (as they would be run in threads, this is different from single tool case)
+    """
+
+    agent = BedrockConverseAgent(
+        model_id="dummy", session=mock_bedrock_converse.session()
+    )
+    test_span_name = "test_tools_can_access_agent_context"
+    test_auth_context_principal_id = "test-principal-id"
+    test_conversation_id = "test-conversation-id"
+
+    def dummy_tool() -> str:
+        """
+        Returns a static string
+        """
+        context = AgentContext.current()
+
+        with context.tracer.trace(test_span_name + "_1") as trace:
+            trace.add_attribute("test.auth.context", context.auth_context)
+            trace.add_attribute("test.conversation.id", context.conversation_id)
+
+        return "static string"
+
+    def dummy_tool2() -> str:
+        """
+        Returns a static string
+        """
+        context = AgentContext.current()
+
+        with context.tracer.trace(test_span_name + "_2") as trace:
+            trace.add_attribute("test.auth.context", context.auth_context)
+            trace.add_attribute("test.conversation.id", context.conversation_id)
+
+        return "static string"
+
+    agent.register_tool(dummy_tool)
+    agent.register_tool(dummy_tool2)
+
+    mock_bedrock_converse.add_output(
+        tool_use_output=[
+            {"name": "dummy_tool", "input": {}},
+            {"name": "dummy_tool2", "input": {}},
+        ]
+    )
+    mock_bedrock_converse.add_output("Agent response")
+
+    agent.set_auth_context(principal_id=test_auth_context_principal_id)
+    agent.set_conversation_id(test_conversation_id)
+    agent.converse("Test message")
+
+    for span_name_suffix in ["_1", "_2"]:
+        span_name = test_span_name + span_name_suffix
+        for trace in agent.traces:
+            if trace.span_name == span_name:
+                assert (
+                    trace.attributes["test.auth.context"]["principal_id"]
+                    == test_auth_context_principal_id
+                )
+                assert trace.attributes["test.conversation.id"] == test_conversation_id
+                break
+        else:
+            raise Exception(f"Did not find test span {span_name} in traces!")

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from generative_ai_toolkit.context import AuthContext
+from generative_ai_toolkit.run.agent import Runner
+
+
+def test_runner_happy_flow(mock_agent_1, mock_bedrock_converse):
+    # Configure mock responses for a weather conversation
+    mock_bedrock_converse.add_output(
+        text_output=["Let me check the weather for you."],
+        tool_use_output=[{"name": "weather_tool", "input": {"city": "Paris"}}],
+    )
+    mock_bedrock_converse.add_output(
+        text_output=["The weather in Paris is 20 degrees celsius. It's quite pleasant!"]
+    )
+    mock_bedrock_converse.add_output(text_output=["20 degrees celsius."])
+
+    # Custom auth context function that reads x-user-id header
+    def test_auth_context_fn(request) -> AuthContext:
+        user_id = request.headers.get("x-user-id")
+        if not user_id:
+            raise ValueError("Missing x-user-id header")
+        return {"principal_id": user_id}
+
+    # Configure Runner with agent factory and custom auth
+    Runner.configure(
+        agent=mock_agent_1,
+        auth_context_fn=test_auth_context_fn,
+    )
+
+    # Test initial request
+    with Runner().test_client() as client:
+        response = client.post(
+            "/",
+            json={"user_input": "What's the weather like in Paris?"},
+            headers={
+                "Content-Type": "application/json",
+                "x-user-id": "test-user-123",  # Set user ID in header
+            },
+        )
+
+        # Assert response properties
+        assert response.status_code == 200
+        assert response.content_type == "text/plain; charset=utf-8"
+        assert "x-conversation-id" in response.headers
+
+        # Collect streaming response
+        full_response = b"".join(response.response).decode()  # type: ignore
+        assert "20 degrees celsius" in full_response
+
+        conversation_id = response.headers["x-conversation-id"]
+
+        # Test conversation continuation
+        response2 = client.post(
+            "/",
+            json={"user_input": "What was that temperature again?"},
+            headers={
+                "Content-Type": "application/json",
+                "x-conversation-id": conversation_id,
+                "x-user-id": "test-user-123",  # Same user continues conversation
+            },
+        )
+
+        assert response2.status_code == 200
+        assert (
+            response2.headers["x-conversation-id"] == conversation_id
+        )  # Same conversation
+        full_response2 = b"".join(response2.response).decode()  # type: ignore
+        assert "20 degrees celsius" in full_response2

--- a/tests/unit/test_tool_response.py
+++ b/tests/unit/test_tool_response.py
@@ -16,9 +16,7 @@ import json
 from datetime import UTC, date, datetime, time
 
 from generative_ai_toolkit.agent import BedrockConverseAgent
-from generative_ai_toolkit.agent.tool import (
-    ToolResultJsonEncoder,
-)
+from generative_ai_toolkit.utils.json import DefaultJsonEncoder
 
 
 class Foo:
@@ -35,7 +33,7 @@ def test_tool_result_json_encoder():
     foo = Foo()
 
     assert (
-        json.dumps(foo, cls=ToolResultJsonEncoder)
+        json.dumps(foo, cls=DefaultJsonEncoder)
         == '{"foo": "bar", "bar": "2021-01-01T01:01:01+00:00", "baz": "2022-02-02", "qux": "01:02:03.000004"}'
     )
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

Tools can now access contextual information about the current agent execution through the `AgentContext` class. This enables tools to create detailed trace spans for better observability and debugging, and access authentication context to implement user-specific behavior:

```python
from generative_ai_toolkit.context import AgentContext

def context_aware_tool(some_parameter: str) -> str:
    """
    A tool that demonstrates access to agent context

    Parameters
    ----------
    some_parameter : str
        Some parameter
    """

    # Access the current agent context:
    context = AgentContext.current()

    # Access conversation and authentication information:
    conversation_id = context.conversation_id
    principal_id = context.auth_context["principal_id"]
    other_auth_data = context.auth_context["extra"]["other_auth_data"]

    # Access the tracer to be able to use it from within the tool
    # Add attributes to the current span:
    current_trace = context.tracer.current_trace
    current_trace.add_attribute("foo", "bar")

    # Start a new span:
    with context.tracer.trace("new-span") as trace:
        ...

    return "response"

agent.register_tool(context_aware_tool)

# Set context on your agent:
agent.set_conversation_id("01J5D9ZNK5XKZX472HC81ZYR5Z")
agent.set_auth_context(principal_id="john", extra={"other_auth_data":"foo"})

# Now, when the agent invokes the tool during the conversation, the tool can access the context
agent.converse("Hello!")
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
