### PR TITLE
feat: chat ui supports concurrent conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1935,6 +1935,29 @@ This interactive UI is meant for development and testing phases, to quickly iter
 
 <img src="./assets/images/ui-chat.png" alt="UI Chat Interface Screenshot" title="UI Chat Interface" width="1200"/>
 
+##### Concurrent conversations
+
+To support concurrent conversations, e.g. in multiple browser tabs, pass an agent factory instead of an agent instance:
+
+```python
+from generative_ai_toolkit.ui import chat_ui
+
+def agent_factory():
+    agent = BedrockConverseAgent(
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        system_prompt="You are a helpful assistant"
+    )
+
+    # Register any tools as needed
+    agent.register_tool(my_tool_function)
+
+    return agent
+
+# Create and launch the chat UI
+demo = chat_ui(agent_factory)
+demo.queue(default_concurrency_limit=10).launch(inbrowser=True)
+```
+
 ### 2.10 Mocking and Testing
 
 As with all software, you'll want to test your agent. You can use above mentioned [Cases](#25-repeatable-cases) for evaluating your agent in an end-to-end testing style. You may also want to create integration tests and unit tests, e.g. to target specific code paths in isolation. For such tests you can use the following tools from the Generative AI Toolkit:

--- a/src/generative_ai_toolkit/agent/agent.py
+++ b/src/generative_ai_toolkit/agent/agent.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     )
 
 
+@runtime_checkable
 class Agent(Tool, Protocol):
     @property
     def model_id(self) -> str:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* You can now have different conversations with the chat UI, e.g. in multiple browser tabs.

To enable this the conversation ID is used as query parameter: `http://127.0.0.1:7860/?conversation-id=01K1JJQS289G6WSF1XTS2SVNSY` (and is set automatically if you don't explicitly set it)

Pass an agent factory instead of an agent instance to make it work:

```python
from generative_ai_toolkit.ui import chat_ui

def agent_factory():
    agent = BedrockConverseAgent(
        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
        system_prompt="You are a helpful assistant"
    )

    # Register any tools as needed
    agent.register_tool(my_tool_function)

    return agent

# Create and launch the chat UI
demo = chat_ui(agent_factory)
demo.queue(default_concurrency_limit=10).launch(inbrowser=True)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
